### PR TITLE
Update GitHub Actions to use pinned hashes

### DIFF
--- a/.github/workflows/_shared-build.yaml
+++ b/.github/workflows/_shared-build.yaml
@@ -46,13 +46,13 @@ jobs:
     name: Build linux/amd64 binary
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
       with:
         ref: ${{ inputs.ref }}
 
     # setup global dependencies
     - name: Set up go
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4
       with:
         go-version: 1.22.x
     
@@ -70,7 +70,7 @@ jobs:
 
     # upload artifacts
     - name: "Upload artifact: eth-beacon-genesis_linux_amd64"
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4
       with:
         path: ./bin/*
         name: eth-beacon-genesis_linux_amd64
@@ -79,13 +79,13 @@ jobs:
     name: Build linux/arm64 binary
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
       with:
         ref: ${{ inputs.ref }}
 
     # setup global dependencies
     - name: Set up go
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4
       with:
         go-version: 1.22.x
 
@@ -109,7 +109,7 @@ jobs:
 
     # upload artifacts
     - name: "Upload artifact: eth-beacon-genesis_linux_arm64"
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4
       with:
         path: ./bin/*
         name: eth-beacon-genesis_linux_arm64
@@ -118,13 +118,13 @@ jobs:
     name: Build windows/amd64 binary
     runs-on: windows-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
       with:
         ref: ${{ inputs.ref }}
 
     # setup global dependencies
     - name: Set up go
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4
       with:
         go-version: 1.22.x
 
@@ -142,7 +142,7 @@ jobs:
 
     # upload artifacts
     - name: "Upload artifact: eth-beacon-genesis_windows_amd64"
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4
       with:
         path: ./bin/*
         name: eth-beacon-genesis_windows_amd64
@@ -151,13 +151,13 @@ jobs:
     name: Build macos/amd64 binary
     runs-on: macos-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
       with:
         ref: ${{ inputs.ref }}
 
     # setup global dependencies
     - name: Set up go
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4
       with:
         go-version: 1.22.x
 
@@ -175,7 +175,7 @@ jobs:
 
     # upload artifacts
     - name: "Upload artifact: eth-beacon-genesis_darwin_amd64"
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4
       with:
         path: ./bin/*
         name: eth-beacon-genesis_darwin_amd64
@@ -184,13 +184,13 @@ jobs:
     name: Build macos/arm64 binary
     runs-on: macos-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
       with:
         ref: ${{ inputs.ref }}
 
     # setup global dependencies
     - name: Set up go
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4
       with:
         go-version: 1.22.x
 
@@ -208,7 +208,7 @@ jobs:
 
     # upload artifacts
     - name: "Upload artifact: eth-beacon-genesis_darwin_arm64"
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4
       with:
         path: ./bin/*
         name: eth-beacon-genesis_darwin_arm64
@@ -219,7 +219,7 @@ jobs:
     if: ${{ inputs.docker }}
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
       with:
         ref: ${{ inputs.ref }}
 
@@ -229,16 +229,16 @@ jobs:
 
     # prepare docker
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v2
+      uses: docker/setup-buildx-action@885d1462b80bc1c1c7f0b00334ad271f09369c55 # v2
     - name: Login to Docker Hub
-      uses: docker/login-action@v2
+      uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc # v2
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
 
     # download build artifacts
     - name: Download build artifacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4
       with:
         name: eth-beacon-genesis_linux_amd64
         path: ./bin
@@ -267,7 +267,7 @@ jobs:
     if: ${{ inputs.docker }}
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
       with:
         ref: ${{ inputs.ref }}
     - name: Get build version
@@ -276,18 +276,18 @@ jobs:
 
     # prepare docker
     - name: Set up Docker QEMU
-      uses: docker/setup-qemu-action@v2
+      uses: docker/setup-qemu-action@2b82ce82d56a2a04d2637cd93a637ae1b359c0a7 # v2
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v2
+      uses: docker/setup-buildx-action@885d1462b80bc1c1c7f0b00334ad271f09369c55 # v2
     - name: Login to Docker Hub
-      uses: docker/login-action@v2
+      uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc # v2
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
 
     # download build artifacts
     - name: Download build artifacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4
       with:
         name: eth-beacon-genesis_linux_arm64
         path: ./bin
@@ -316,7 +316,7 @@ jobs:
     if: ${{ inputs.docker }}
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
       with:
         ref: ${{ inputs.ref }}
     - name: Get build version
@@ -325,9 +325,9 @@ jobs:
 
     # prepare docker
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v2
+      uses: docker/setup-buildx-action@885d1462b80bc1c1c7f0b00334ad271f09369c55 # v2
     - name: Login to Docker Hub
-      uses: docker/login-action@v2
+      uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc # v2
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -351,7 +351,7 @@ jobs:
       matrix:
         tag: ${{ fromJSON(inputs.additional_tags) }}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
       with:
         ref: ${{ inputs.ref }}
     - name: Get build version
@@ -360,9 +360,9 @@ jobs:
 
     # prepare docker
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v2
+      uses: docker/setup-buildx-action@885d1462b80bc1c1c7f0b00334ad271f09369c55 # v2
     - name: Login to Docker Hub
-      uses: docker/login-action@v2
+      uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc # v2
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/_shared-check.yaml
+++ b/.github/workflows/_shared-check.yaml
@@ -9,11 +9,11 @@ jobs:
     name: Run code checks
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
 
     # setup global dependencies
     - name: Set up go
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4
       with:
         go-version: 1.21.x
     
@@ -33,7 +33,7 @@ jobs:
 
 
     - name: Run golangci-lint
-      uses: golangci/golangci-lint-action@v3
+      uses: golangci/golangci-lint-action@3a919529898de77ec3da873e3063ca4b10e7f5cc # v3
       with:
         # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
         version: v1.64.5
@@ -60,4 +60,4 @@ jobs:
     - name: Run tests
       run: go test -race -coverprofile=coverage.out -covermode=atomic -vet=off ./...
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@ab904c41d6ece82784817410c45d8b8c02684457 # v3

--- a/.github/workflows/build-master.yml
+++ b/.github/workflows/build-master.yml
@@ -42,11 +42,11 @@ jobs:
     steps:
     # download build artifacts
     - name: "Download build artifacts"
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4
 
     # (re)create snapshot binary release
     - name: Update snapshot tag & remove previous snapshot release
-      uses: actions/github-script@v3
+      uses: actions/github-script@ffc2c79a5b2490bd33e0a41c1de74b877714d736 # v3
       with:
         github-token: ${{secrets.GITHUB_TOKEN}}
         script: |
@@ -93,7 +93,7 @@ jobs:
             console.log(e)
           }
     - name: Create snapshot release
-      uses: actions/create-release@v1
+      uses: actions/create-release@0cb9c9b65d5d1901c1f53e5e66eaf4afd303e70e # v1
       id: create_release
       with:
         draft: false
@@ -121,7 +121,7 @@ jobs:
         cd eth-beacon-genesis_windows_amd64
         zip -r -q ../eth-beacon-genesis_snapshot_windows_amd64.zip .
     - name: "Upload snapshot release artifact: eth-beacon-genesis_snapshot_windows_amd64.zip"
-      uses: actions/upload-release-asset@v1
+      uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 # v1
       with:
         upload_url: ${{ steps.create_release.outputs.upload_url }}
         asset_path: ./eth-beacon-genesis_snapshot_windows_amd64.zip
@@ -135,7 +135,7 @@ jobs:
         cd eth-beacon-genesis_linux_amd64
         tar -czf ../eth-beacon-genesis_snapshot_linux_amd64.tar.gz .
     - name: "Upload snapshot release artifact: eth-beacon-genesis_snapshot_linux_amd64.tar.gz"
-      uses: actions/upload-release-asset@v1
+      uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 # v1
       with:
         upload_url: ${{ steps.create_release.outputs.upload_url }}
         asset_path: ./eth-beacon-genesis_snapshot_linux_amd64.tar.gz
@@ -149,7 +149,7 @@ jobs:
         cd eth-beacon-genesis_linux_arm64
         tar -czf ../eth-beacon-genesis_snapshot_linux_arm64.tar.gz .
     - name: "Upload snapshot release artifact: eth-beacon-genesis_snapshot_linux_arm64.tar.gz"
-      uses: actions/upload-release-asset@v1
+      uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 # v1
       with:
         upload_url: ${{ steps.create_release.outputs.upload_url }}
         asset_path: ./eth-beacon-genesis_snapshot_linux_arm64.tar.gz
@@ -163,7 +163,7 @@ jobs:
         cd eth-beacon-genesis_darwin_amd64
         tar -czf ../eth-beacon-genesis_snapshot_darwin_amd64.tar.gz .
     - name: "Upload snapshot release artifact: eth-beacon-genesis_snapshot_darwin_amd64.tar.gz"
-      uses: actions/upload-release-asset@v1
+      uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 # v1
       with:
         upload_url: ${{ steps.create_release.outputs.upload_url }}
         asset_path: ./eth-beacon-genesis_snapshot_darwin_amd64.tar.gz
@@ -177,7 +177,7 @@ jobs:
         cd eth-beacon-genesis_darwin_arm64
         tar -czf ../eth-beacon-genesis_snapshot_darwin_arm64.tar.gz .
     - name: "Upload snapshot release artifact: eth-beacon-genesis_snapshot_darwin_arm64.tar.gz"
-      uses: actions/upload-release-asset@v1
+      uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 # v1
       with:
         upload_url: ${{ steps.create_release.outputs.upload_url }}
         asset_path: ./eth-beacon-genesis_snapshot_darwin_arm64.tar.gz

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -31,7 +31,7 @@ jobs:
     needs: [build_binaries]
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
       with:
         fetch-depth: 100
         ref: ${{ github.sha }}
@@ -52,11 +52,11 @@ jobs:
 
     # download build artifacts
     - name: "Download build artifacts"
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4
 
     # create draft release
     - name: Create latest release
-      uses: actions/create-release@v1
+      uses: actions/create-release@0cb9c9b65d5d1901c1f53e5e66eaf4afd303e70e # v1
       id: create_release
       with:
         draft: true
@@ -84,7 +84,7 @@ jobs:
         cd eth-beacon-genesis_windows_amd64
         zip -r -q ../eth-beacon-genesis_${{ inputs.version }}_windows_amd64.zip .
     - name: "Upload release artifact: eth-beacon-genesis_${{ inputs.version }}_windows_amd64.zip"
-      uses: actions/upload-release-asset@v1
+      uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 # v1
       with:
         upload_url: ${{ steps.create_release.outputs.upload_url }}
         asset_path: ./eth-beacon-genesis_${{ inputs.version }}_windows_amd64.zip
@@ -98,7 +98,7 @@ jobs:
         cd eth-beacon-genesis_linux_amd64
         tar -czf ../eth-beacon-genesis_${{ inputs.version }}_linux_amd64.tar.gz .
     - name: "Upload release artifact: eth-beacon-genesis_${{ inputs.version }}_linux_amd64.tar.gz"
-      uses: actions/upload-release-asset@v1
+      uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 # v1
       with:
         upload_url: ${{ steps.create_release.outputs.upload_url }}
         asset_path: ./eth-beacon-genesis_${{ inputs.version }}_linux_amd64.tar.gz
@@ -112,7 +112,7 @@ jobs:
         cd eth-beacon-genesis_linux_arm64
         tar -czf ../eth-beacon-genesis_${{ inputs.version }}_linux_arm64.tar.gz .
     - name: "Upload release artifact: eth-beacon-genesis_${{ inputs.version }}_linux_arm64.tar.gz"
-      uses: actions/upload-release-asset@v1
+      uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 # v1
       with:
         upload_url: ${{ steps.create_release.outputs.upload_url }}
         asset_path: ./eth-beacon-genesis_${{ inputs.version }}_linux_arm64.tar.gz
@@ -126,7 +126,7 @@ jobs:
         cd eth-beacon-genesis_darwin_amd64
         tar -czf ../eth-beacon-genesis_${{ inputs.version }}_darwin_amd64.tar.gz .
     - name: "Upload release artifact: eth-beacon-genesis_${{ inputs.version }}_darwin_amd64.tar.gz"
-      uses: actions/upload-release-asset@v1
+      uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 # v1
       with:
         upload_url: ${{ steps.create_release.outputs.upload_url }}
         asset_path: ./eth-beacon-genesis_${{ inputs.version }}_darwin_amd64.tar.gz
@@ -140,7 +140,7 @@ jobs:
         cd eth-beacon-genesis_darwin_arm64
         tar -czf ../eth-beacon-genesis_${{ inputs.version }}_darwin_arm64.tar.gz .
     - name: "Upload release artifact: eth-beacon-genesis_${{ inputs.version }}_darwin_arm64.tar.gz"
-      uses: actions/upload-release-asset@v1
+      uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 # v1
       with:
         upload_url: ${{ steps.create_release.outputs.upload_url }}
         asset_path: ./eth-beacon-genesis_${{ inputs.version }}_darwin_arm64.tar.gz


### PR DESCRIPTION
This PR updates GitHub Actions to use pinned commit hashes for better security.