### PR TITLE
add support for leanchain genesis (devnet0)

### DIFF
--- a/beaconchain/altair.go
+++ b/beaconchain/altair.go
@@ -14,7 +14,7 @@ import (
 
 	"github.com/ethpandaops/eth-beacon-genesis/beaconconfig"
 	"github.com/ethpandaops/eth-beacon-genesis/beaconutils"
-	"github.com/ethpandaops/eth-beacon-genesis/validators"
+	"github.com/ethpandaops/eth-beacon-genesis/beaconvalidators"
 )
 
 type altairBuilder struct {
@@ -22,7 +22,7 @@ type altairBuilder struct {
 	clConfig        *beaconconfig.Config
 	dynSsz          *dynssz.DynSsz
 	shadowForkBlock *types.Block
-	validators      []*validators.Validator
+	validators      []*beaconvalidators.Validator
 }
 
 func NewAltairBuilder(elGenesis *core.Genesis, clConfig *beaconconfig.Config) BeaconGenesisBuilder {
@@ -37,7 +37,7 @@ func (b *altairBuilder) SetShadowForkBlock(block *types.Block) {
 	b.shadowForkBlock = block
 }
 
-func (b *altairBuilder) AddValidators(val []*validators.Validator) {
+func (b *altairBuilder) AddValidators(val []*beaconvalidators.Validator) {
 	b.validators = append(b.validators, val...)
 }
 

--- a/beaconchain/bellatrix.go
+++ b/beaconchain/bellatrix.go
@@ -15,7 +15,7 @@ import (
 
 	"github.com/ethpandaops/eth-beacon-genesis/beaconconfig"
 	"github.com/ethpandaops/eth-beacon-genesis/beaconutils"
-	"github.com/ethpandaops/eth-beacon-genesis/validators"
+	"github.com/ethpandaops/eth-beacon-genesis/beaconvalidators"
 	dynssz "github.com/pk910/dynamic-ssz"
 )
 
@@ -24,7 +24,7 @@ type bellatrixBuilder struct {
 	clConfig        *beaconconfig.Config
 	dynSsz          *dynssz.DynSsz
 	shadowForkBlock *types.Block
-	validators      []*validators.Validator
+	validators      []*beaconvalidators.Validator
 }
 
 func NewBellatrixBuilder(elGenesis *core.Genesis, clConfig *beaconconfig.Config) BeaconGenesisBuilder {
@@ -39,7 +39,7 @@ func (b *bellatrixBuilder) SetShadowForkBlock(block *types.Block) {
 	b.shadowForkBlock = block
 }
 
-func (b *bellatrixBuilder) AddValidators(val []*validators.Validator) {
+func (b *bellatrixBuilder) AddValidators(val []*beaconvalidators.Validator) {
 	b.validators = append(b.validators, val...)
 }
 

--- a/beaconchain/capella.go
+++ b/beaconchain/capella.go
@@ -16,7 +16,7 @@ import (
 
 	"github.com/ethpandaops/eth-beacon-genesis/beaconconfig"
 	"github.com/ethpandaops/eth-beacon-genesis/beaconutils"
-	"github.com/ethpandaops/eth-beacon-genesis/validators"
+	"github.com/ethpandaops/eth-beacon-genesis/beaconvalidators"
 	dynssz "github.com/pk910/dynamic-ssz"
 )
 
@@ -25,7 +25,7 @@ type capellaBuilder struct {
 	clConfig        *beaconconfig.Config
 	dynSsz          *dynssz.DynSsz
 	shadowForkBlock *types.Block
-	validators      []*validators.Validator
+	validators      []*beaconvalidators.Validator
 }
 
 func NewCapellaBuilder(elGenesis *core.Genesis, clConfig *beaconconfig.Config) BeaconGenesisBuilder {
@@ -40,7 +40,7 @@ func (b *capellaBuilder) SetShadowForkBlock(block *types.Block) {
 	b.shadowForkBlock = block
 }
 
-func (b *capellaBuilder) AddValidators(val []*validators.Validator) {
+func (b *capellaBuilder) AddValidators(val []*beaconvalidators.Validator) {
 	b.validators = append(b.validators, val...)
 }
 

--- a/beaconchain/deneb.go
+++ b/beaconchain/deneb.go
@@ -16,7 +16,7 @@ import (
 
 	"github.com/ethpandaops/eth-beacon-genesis/beaconconfig"
 	"github.com/ethpandaops/eth-beacon-genesis/beaconutils"
-	"github.com/ethpandaops/eth-beacon-genesis/validators"
+	"github.com/ethpandaops/eth-beacon-genesis/beaconvalidators"
 	dynssz "github.com/pk910/dynamic-ssz"
 )
 
@@ -25,7 +25,7 @@ type denebBuilder struct {
 	clConfig        *beaconconfig.Config
 	dynSsz          *dynssz.DynSsz
 	shadowForkBlock *types.Block
-	validators      []*validators.Validator
+	validators      []*beaconvalidators.Validator
 }
 
 func NewDenebBuilder(elGenesis *core.Genesis, clConfig *beaconconfig.Config) BeaconGenesisBuilder {
@@ -40,7 +40,7 @@ func (b *denebBuilder) SetShadowForkBlock(block *types.Block) {
 	b.shadowForkBlock = block
 }
 
-func (b *denebBuilder) AddValidators(val []*validators.Validator) {
+func (b *denebBuilder) AddValidators(val []*beaconvalidators.Validator) {
 	b.validators = append(b.validators, val...)
 }
 

--- a/beaconchain/electra.go
+++ b/beaconchain/electra.go
@@ -17,7 +17,7 @@ import (
 
 	"github.com/ethpandaops/eth-beacon-genesis/beaconconfig"
 	"github.com/ethpandaops/eth-beacon-genesis/beaconutils"
-	"github.com/ethpandaops/eth-beacon-genesis/validators"
+	"github.com/ethpandaops/eth-beacon-genesis/beaconvalidators"
 	dynssz "github.com/pk910/dynamic-ssz"
 )
 
@@ -26,7 +26,7 @@ type electraBuilder struct {
 	clConfig        *beaconconfig.Config
 	dynSsz          *dynssz.DynSsz
 	shadowForkBlock *types.Block
-	validators      []*validators.Validator
+	validators      []*beaconvalidators.Validator
 }
 
 func NewElectraBuilder(elGenesis *core.Genesis, clConfig *beaconconfig.Config) BeaconGenesisBuilder {
@@ -41,7 +41,7 @@ func (b *electraBuilder) SetShadowForkBlock(block *types.Block) {
 	b.shadowForkBlock = block
 }
 
-func (b *electraBuilder) AddValidators(val []*validators.Validator) {
+func (b *electraBuilder) AddValidators(val []*beaconvalidators.Validator) {
 	b.validators = append(b.validators, val...)
 }
 

--- a/beaconchain/fulu.go
+++ b/beaconchain/fulu.go
@@ -18,7 +18,7 @@ import (
 
 	"github.com/ethpandaops/eth-beacon-genesis/beaconconfig"
 	"github.com/ethpandaops/eth-beacon-genesis/beaconutils"
-	"github.com/ethpandaops/eth-beacon-genesis/validators"
+	"github.com/ethpandaops/eth-beacon-genesis/beaconvalidators"
 	dynssz "github.com/pk910/dynamic-ssz"
 )
 
@@ -27,7 +27,7 @@ type fuluBuilder struct {
 	clConfig        *beaconconfig.Config
 	dynSsz          *dynssz.DynSsz
 	shadowForkBlock *types.Block
-	validators      []*validators.Validator
+	validators      []*beaconvalidators.Validator
 }
 
 func NewFuluBuilder(elGenesis *core.Genesis, clConfig *beaconconfig.Config) BeaconGenesisBuilder {
@@ -42,7 +42,7 @@ func (b *fuluBuilder) SetShadowForkBlock(block *types.Block) {
 	b.shadowForkBlock = block
 }
 
-func (b *fuluBuilder) AddValidators(val []*validators.Validator) {
+func (b *fuluBuilder) AddValidators(val []*beaconvalidators.Validator) {
 	b.validators = append(b.validators, val...)
 }
 

--- a/beaconchain/generator.go
+++ b/beaconchain/generator.go
@@ -9,14 +9,14 @@ import (
 	hbls "github.com/herumi/bls-eth-go-binary/bls"
 
 	"github.com/ethpandaops/eth-beacon-genesis/beaconconfig"
-	"github.com/ethpandaops/eth-beacon-genesis/validators"
+	"github.com/ethpandaops/eth-beacon-genesis/beaconvalidators"
 )
 
 type NewBeaconGenesisBuilderFn func(elGenesis *core.Genesis, clConfig *beaconconfig.Config) BeaconGenesisBuilder
 
 type BeaconGenesisBuilder interface {
 	SetShadowForkBlock(block *types.Block)
-	AddValidators(validators []*validators.Validator)
+	AddValidators(validators []*beaconvalidators.Validator)
 	BuildState() (*spec.VersionedBeaconState, error)
 	Serialize(state *spec.VersionedBeaconState, contentType http.ContentType) ([]byte, error)
 }

--- a/beaconchain/phase0.go
+++ b/beaconchain/phase0.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/ethpandaops/eth-beacon-genesis/beaconconfig"
 	"github.com/ethpandaops/eth-beacon-genesis/beaconutils"
-	"github.com/ethpandaops/eth-beacon-genesis/validators"
+	"github.com/ethpandaops/eth-beacon-genesis/beaconvalidators"
 	dynssz "github.com/pk910/dynamic-ssz"
 )
 
@@ -21,7 +21,7 @@ type phase0Builder struct {
 	clConfig        *beaconconfig.Config
 	dynSsz          *dynssz.DynSsz
 	shadowForkBlock *types.Block
-	validators      []*validators.Validator
+	validators      []*beaconvalidators.Validator
 }
 
 func NewPhase0Builder(elGenesis *core.Genesis, clConfig *beaconconfig.Config) BeaconGenesisBuilder {
@@ -36,7 +36,7 @@ func (b *phase0Builder) SetShadowForkBlock(block *types.Block) {
 	b.shadowForkBlock = block
 }
 
-func (b *phase0Builder) AddValidators(val []*validators.Validator) {
+func (b *phase0Builder) AddValidators(val []*beaconvalidators.Validator) {
 	b.validators = append(b.validators, val...)
 }
 

--- a/beaconutils/depositroot.go
+++ b/beaconutils/depositroot.go
@@ -5,6 +5,7 @@ import (
 	ssz "github.com/ferranbt/fastssz"
 
 	"github.com/ethpandaops/eth-beacon-genesis/beaconconfig"
+	"github.com/ethpandaops/eth-beacon-genesis/coreutils"
 )
 
 func ComputeDepositRoot(cfg *beaconconfig.Config) (phase0.Root, error) {
@@ -12,7 +13,7 @@ func ComputeDepositRoot(cfg *beaconconfig.Config) (phase0.Root, error) {
 	// since that is what we put as eth1_data.deposit_root in the CL genesis state.
 	maxDeposits := cfg.GetUintDefault("MAX_DEPOSITS_PER_PAYLOAD", 1<<cfg.GetUintDefault("DEPOSIT_CONTRACT_TREE_DEPTH", 32))
 
-	depositRoot, _ := HashWithFastSSZHasher(func(hh *ssz.Hasher) error {
+	depositRoot, _ := coreutils.HashWithFastSSZHasher(func(hh *ssz.Hasher) error {
 		hh.MerkleizeWithMixin(0, 0, maxDeposits)
 		return nil
 	})

--- a/beaconutils/proposers.go
+++ b/beaconutils/proposers.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/attestantio/go-eth2-client/spec/phase0"
 	"github.com/ethpandaops/eth-beacon-genesis/beaconconfig"
+	"github.com/ethpandaops/eth-beacon-genesis/coreutils"
 )
 
 // GetGenesisProposers returns the proposer indices for the first 2 epochs
@@ -87,7 +88,7 @@ func computeProposerIndex(clConfig *beaconconfig.Config, validators []*phase0.Va
 		binary.LittleEndian.PutUint64(buf[32:], i/16)
 		hash := sha256.Sum256(buf)
 		offset := (i % 16) * 2
-		randomValue := BytesToUint(hash[offset : offset+2])
+		randomValue := coreutils.BytesToUint(hash[offset : offset+2])
 
 		// Check if this validator is selected as proposer
 		if uint64(effectiveBalance)*maxRandomValue >= maxEffectiveBalance*randomValue {

--- a/beaconutils/synccommittee.go
+++ b/beaconutils/synccommittee.go
@@ -10,6 +10,7 @@ import (
 	blsu "github.com/protolambda/bls12-381-util"
 
 	"github.com/ethpandaops/eth-beacon-genesis/beaconconfig"
+	"github.com/ethpandaops/eth-beacon-genesis/coreutils"
 )
 
 func GetGenesisSyncCommittee(cfg *beaconconfig.Config, validators []*phase0.Validator, randaoMix phase0.Hash32) (*altair.SyncCommittee, error) {
@@ -148,7 +149,7 @@ func computeGenesisSyncCommitteeIndicesElectra(cfg *beaconconfig.Config, active 
 			h = sha256.Sum256(buf[:])
 		}
 
-		randomValue := BytesToUint(h[(i%16)*2 : (i%16)*2+2])
+		randomValue := coreutils.BytesToUint(h[(i%16)*2 : (i%16)*2+2])
 
 		if effectiveBalance*0xffff >= phase0.Gwei(maxEffectiveBalance)*phase0.Gwei(randomValue) {
 			syncCommitteeIndices = append(syncCommitteeIndices, candidateIndex)
@@ -163,7 +164,7 @@ func computeGenesisSyncCommitteeIndicesElectra(cfg *beaconconfig.Config, active 
 func computeGenesisSeed(mix phase0.Hash32, epoch phase0.Epoch, domainType phase0.DomainType) phase0.Root {
 	data := []byte{}
 	data = append(data, domainType[:]...)
-	data = append(data, UintToBytes(uint64(epoch))...)
+	data = append(data, coreutils.UintToBytes(uint64(epoch))...)
 	data = append(data, mix[:]...)
 
 	return sha256.Sum256(data)

--- a/beaconutils/transactions.go
+++ b/beaconutils/transactions.go
@@ -9,6 +9,7 @@ import (
 	ssz "github.com/ferranbt/fastssz"
 
 	"github.com/ethpandaops/eth-beacon-genesis/beaconconfig"
+	"github.com/ethpandaops/eth-beacon-genesis/coreutils"
 )
 
 func ComputeTransactionsRoot(transactions types.Transactions, cfg *beaconconfig.Config) (phase0.Root, error) {
@@ -35,7 +36,7 @@ func ComputeTransactionsRoot(transactions types.Transactions, cfg *beaconconfig.
 
 	maxBytesPerTx := cfg.GetUintDefault("MAX_BYTES_PER_TRANSACTION", 1073741824)
 
-	transactionsRoot, err := HashWithFastSSZHasher(func(hh *ssz.Hasher) error {
+	transactionsRoot, err := coreutils.HashWithFastSSZHasher(func(hh *ssz.Hasher) error {
 		for i, elem := range clTransactions {
 			elemIndx := hh.Index()
 			byteLen := uint64(len(elem))

--- a/beaconutils/validators.go
+++ b/beaconutils/validators.go
@@ -5,10 +5,11 @@ import (
 	ssz "github.com/ferranbt/fastssz"
 
 	"github.com/ethpandaops/eth-beacon-genesis/beaconconfig"
-	"github.com/ethpandaops/eth-beacon-genesis/validators"
+	"github.com/ethpandaops/eth-beacon-genesis/beaconvalidators"
+	"github.com/ethpandaops/eth-beacon-genesis/coreutils"
 )
 
-func GetGenesisValidators(cfg *beaconconfig.Config, vals []*validators.Validator) ([]*phase0.Validator, phase0.Root) {
+func GetGenesisValidators(cfg *beaconconfig.Config, vals []*beaconvalidators.Validator) ([]*phase0.Validator, phase0.Root) {
 	// Process activations
 	maxEffectiveBalance := phase0.Gwei(cfg.GetUintDefault("MAX_EFFECTIVE_BALANCE", 32_000_000_000))
 	maxEffectiveBalanceElectra := phase0.Gwei(cfg.GetUintDefault("MAX_EFFECTIVE_BALANCE_ELECTRA", 2_048_000_000_000))
@@ -64,7 +65,7 @@ func GetGenesisValidators(cfg *beaconconfig.Config, vals []*validators.Validator
 	}
 
 	maxValidators := cfg.GetUintDefault("VALIDATOR_REGISTRY_LIMIT", 1099511627776)
-	validatorsRoot, err := HashWithFastSSZHasher(func(hh *ssz.Hasher) error {
+	validatorsRoot, err := coreutils.HashWithFastSSZHasher(func(hh *ssz.Hasher) error {
 		for _, elem := range clValidators {
 			if err := elem.HashTreeRootWith(hh); err != nil {
 				return err
@@ -83,7 +84,7 @@ func GetGenesisValidators(cfg *beaconconfig.Config, vals []*validators.Validator
 	return clValidators, validatorsRoot
 }
 
-func GetGenesisBalances(cfg *beaconconfig.Config, vals []*validators.Validator) []phase0.Gwei {
+func GetGenesisBalances(cfg *beaconconfig.Config, vals []*beaconvalidators.Validator) []phase0.Gwei {
 	maxEffectiveBalance := phase0.Gwei(cfg.GetUintDefault("MAX_EFFECTIVE_BALANCE", 32_000_000_000))
 	balances := make([]phase0.Gwei, len(vals))
 

--- a/beaconutils/validators_test.go
+++ b/beaconutils/validators_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/attestantio/go-eth2-client/spec/phase0"
-	"github.com/ethpandaops/eth-beacon-genesis/validators"
+	"github.com/ethpandaops/eth-beacon-genesis/beaconvalidators"
 )
 
 func TestGetGenesisValidators(t *testing.T) {
@@ -14,7 +14,7 @@ func TestGetGenesisValidators(t *testing.T) {
 		name                string
 		preset              string
 		configValues        map[string]interface{}
-		validators          []*validators.Validator
+		validators          []*beaconvalidators.Validator
 		expectedRoot        string
 		expectedValidators  int
 		expectedActivations int
@@ -29,7 +29,7 @@ func TestGetGenesisValidators(t *testing.T) {
 				"VALIDATOR_REGISTRY_LIMIT": uint64(1099511627776),
 				"ELECTRA_FORK_EPOCH":       uint64(18446744073709551615), // disabled
 			},
-			validators: []*validators.Validator{
+			validators: []*beaconvalidators.Validator{
 				{
 					PublicKey:             phase0.BLSPubKey(makeBytes(48, 1)),
 					WithdrawalCredentials: makeBytes(32, 1),
@@ -55,7 +55,7 @@ func TestGetGenesisValidators(t *testing.T) {
 				"VALIDATOR_REGISTRY_LIMIT":      uint64(1099511627776),
 				"ELECTRA_FORK_EPOCH":            uint64(0),
 			},
-			validators: []*validators.Validator{
+			validators: []*beaconvalidators.Validator{
 				{
 					PublicKey:             phase0.BLSPubKey(makeBytes(48, 1)),
 					WithdrawalCredentials: makeBytes(32, 1),
@@ -79,7 +79,7 @@ func TestGetGenesisValidators(t *testing.T) {
 				"FAR_FUTURE_EPOCH":         uint64(18446744073709551615),
 				"VALIDATOR_REGISTRY_LIMIT": uint64(1099511627776),
 			},
-			validators: []*validators.Validator{
+			validators: []*beaconvalidators.Validator{
 				{
 					PublicKey:             phase0.BLSPubKey(makeBytes(48, 1)),
 					WithdrawalCredentials: makeBytes(16, 1), // Invalid: only 16 bytes
@@ -96,7 +96,7 @@ func TestGetGenesisValidators(t *testing.T) {
 				"FAR_FUTURE_EPOCH":         uint64(18446744073709551615),
 				"VALIDATOR_REGISTRY_LIMIT": uint64(1099511627776),
 			},
-			validators: []*validators.Validator{
+			validators: []*beaconvalidators.Validator{
 				nil,
 			},
 			expectedError: true,
@@ -153,7 +153,7 @@ func TestGetGenesisBalances(t *testing.T) {
 		name          string
 		preset        string
 		configValues  map[string]interface{}
-		validators    []*validators.Validator
+		validators    []*beaconvalidators.Validator
 		expectedGweis []uint64
 		expectedError bool
 	}{
@@ -163,7 +163,7 @@ func TestGetGenesisBalances(t *testing.T) {
 			configValues: map[string]interface{}{
 				"MAX_EFFECTIVE_BALANCE": uint64(32_000_000_000),
 			},
-			validators: []*validators.Validator{
+			validators: []*beaconvalidators.Validator{
 				{
 					PublicKey:             phase0.BLSPubKey(makeBytes(48, 1)),
 					WithdrawalCredentials: makeBytes(32, 1),
@@ -183,7 +183,7 @@ func TestGetGenesisBalances(t *testing.T) {
 			configValues: map[string]interface{}{
 				"MAX_EFFECTIVE_BALANCE": uint64(32_000_000_000),
 			},
-			validators: []*validators.Validator{
+			validators: []*beaconvalidators.Validator{
 				{
 					PublicKey:             phase0.BLSPubKey(makeBytes(48, 1)),
 					WithdrawalCredentials: makeBytes(32, 1),

--- a/beaconutils/withdrawals.go
+++ b/beaconutils/withdrawals.go
@@ -10,6 +10,7 @@ import (
 	ssz "github.com/ferranbt/fastssz"
 
 	"github.com/ethpandaops/eth-beacon-genesis/beaconconfig"
+	"github.com/ethpandaops/eth-beacon-genesis/coreutils"
 )
 
 func ComputeWithdrawalsRoot(withdrawals types.Withdrawals, cfg *beaconconfig.Config) (phase0.Root, error) {
@@ -38,7 +39,7 @@ func ComputeWithdrawalsRoot(withdrawals types.Withdrawals, cfg *beaconconfig.Con
 		}
 	}
 
-	withdrawalsRoot, _ := HashWithFastSSZHasher(func(hh *ssz.Hasher) error {
+	withdrawalsRoot, _ := coreutils.HashWithFastSSZHasher(func(hh *ssz.Hasher) error {
 		for _, elem := range clWithdrawals {
 			elem.HashTreeRootWith(hh) //nolint:errcheck // no error possible
 		}

--- a/beaconvalidators/list.go
+++ b/beaconvalidators/list.go
@@ -1,4 +1,4 @@
-package validators
+package beaconvalidators
 
 import (
 	"bufio"

--- a/beaconvalidators/list_test.go
+++ b/beaconvalidators/list_test.go
@@ -1,4 +1,4 @@
-package validators
+package beaconvalidators
 
 import (
 	"bytes"

--- a/beaconvalidators/mnemonic.go
+++ b/beaconvalidators/mnemonic.go
@@ -1,4 +1,4 @@
-package validators
+package beaconvalidators
 
 import (
 	"crypto/sha256"

--- a/beaconvalidators/mnemonic_test.go
+++ b/beaconvalidators/mnemonic_test.go
@@ -1,4 +1,4 @@
-package validators
+package beaconvalidators
 
 import (
 	"bytes"

--- a/beaconvalidators/validators.go
+++ b/beaconvalidators/validators.go
@@ -1,4 +1,4 @@
-package validators
+package beaconvalidators
 
 import (
 	"github.com/attestantio/go-eth2-client/spec/phase0"

--- a/cmd/eth-genesis-state-generator/beaconchain.go
+++ b/cmd/eth-genesis-state-generator/beaconchain.go
@@ -1,0 +1,167 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/attestantio/go-eth2-client/http"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethpandaops/eth-beacon-genesis/beaconchain"
+	"github.com/ethpandaops/eth-beacon-genesis/beaconconfig"
+	"github.com/ethpandaops/eth-beacon-genesis/beaconvalidators"
+	"github.com/ethpandaops/eth-beacon-genesis/buildinfo"
+	"github.com/ethpandaops/eth-beacon-genesis/eth1"
+	"github.com/sirupsen/logrus"
+	"github.com/urfave/cli/v3"
+)
+
+func runBeaconchain(ctx context.Context, cmd *cli.Command) error {
+	eth1Config := cmd.String(eth1ConfigFlag.Name)
+	eth2Config := cmd.String(configFlag.Name)
+	mnemonicsFile := cmd.String(mnemonicsFileFlag.Name)
+	validatorsFile := cmd.String(validatorsFileFlag.Name)
+	shadowForkBlock := cmd.String(shadowForkBlockFlag.Name)
+	shadowForkRPC := cmd.String(shadowForkRPCFlag.Name)
+	stateOutputFile := cmd.String(stateOutputFlag.Name)
+	jsonOutputFile := cmd.String(jsonOutputFlag.Name)
+	quiet := cmd.Bool(quietFlag.Name)
+
+	if quiet {
+		logrus.SetLevel(logrus.PanicLevel)
+	}
+
+	if !quiet {
+		logrus.Infof("eth-beacon-genesis version: %s", buildinfo.GetBuildVersion())
+	}
+
+	elGenesis, err := eth1.LoadEth1GenesisConfig(eth1Config)
+	if err != nil {
+		return fmt.Errorf("failed to load execution genesis: %w", err)
+	}
+
+	logrus.Infof("loaded execution genesis. chainid: %v", elGenesis.Config.ChainID.String())
+
+	clConfig, err := beaconconfig.LoadConfig(eth2Config)
+	if err != nil {
+		return fmt.Errorf("failed to load consensus config: %w", err)
+	}
+
+	logrus.Infof("loaded consensus config. genesis fork version: 0x%x", clConfig.GetBytesDefault("GENESIS_FORK_VERSION", []byte{}))
+
+	var clValidators []*beaconvalidators.Validator
+
+	if mnemonicsFile != "" {
+		vals, err2 := beaconvalidators.GenerateValidatorsByMnemonic(mnemonicsFile)
+		if err2 != nil {
+			return fmt.Errorf("failed to load validators from mnemonics file: %w", err2)
+		}
+
+		if len(vals) > 0 {
+			clValidators = vals
+		}
+	}
+
+	if validatorsFile != "" {
+		vals, err2 := beaconvalidators.LoadValidatorsFromFile(validatorsFile)
+		if err2 != nil {
+			return fmt.Errorf("failed to load validators from file: %w", err2)
+		}
+
+		if len(vals) > 0 {
+			clValidators = append(clValidators, vals...)
+		}
+	}
+
+	if len(clValidators) == 0 {
+		return fmt.Errorf("no validators found")
+	}
+
+	defaultBalance := clConfig.GetUintDefault("MAX_EFFECTIVE_BALANCE", 32_000_000_000)
+	totalBalance := uint64(0)
+
+	for _, val := range clValidators {
+		if val.Balance != nil {
+			totalBalance += *val.Balance
+		} else {
+			totalBalance += defaultBalance
+		}
+	}
+
+	logrus.Infof("loaded %d validators. total balance: %d ETH", len(clValidators), totalBalance/1_000_000_000)
+
+	builder := beaconchain.NewGenesisBuilder(elGenesis, clConfig)
+	builder.AddValidators(clValidators)
+
+	if shadowForkBlock != "" || shadowForkRPC != "" {
+		var gensisBlock *types.Block
+
+		if shadowForkBlock != "" {
+			block, err2 := eth1.LoadBlockFromFile(shadowForkBlock)
+			if err2 != nil {
+				return fmt.Errorf("failed to load shadow fork block from file: %w", err2)
+			}
+
+			logrus.Infof("loaded shadow fork block from file. hash: %s", block.Hash().String())
+
+			gensisBlock = block
+		} else {
+			block, err2 := eth1.GetBlockFromRPC(ctx, shadowForkRPC)
+			if err2 != nil {
+				return fmt.Errorf("failed to get shadow fork block: %w", err2)
+			}
+
+			logrus.Infof("loaded shadow fork block from RPC. hash: %s", block.Hash().String())
+
+			gensisBlock = block
+		}
+
+		builder.SetShadowForkBlock(gensisBlock)
+	}
+
+	genesisState, err := builder.BuildState()
+	if err != nil {
+		return fmt.Errorf("failed to build genesis: %w", err)
+	}
+
+	logrus.Infof("successfully built genesis state.")
+
+	if stateOutputFile != "" {
+		sszData, err := builder.Serialize(genesisState, http.ContentTypeSSZ)
+		if err != nil {
+			return fmt.Errorf("failed to serialize genesis state: %w", err)
+		}
+
+		if err := os.WriteFile(stateOutputFile, sszData, 0o644); err != nil { //nolint:gosec // no strict permissions needed
+			return fmt.Errorf("failed to write genesis state to SSZ file: %w", err)
+		}
+
+		logrus.Infof("serialized genesis state to SSZ file: %s", stateOutputFile)
+	}
+
+	if jsonOutputFile != "" {
+		jsonData, err := builder.Serialize(genesisState, http.ContentTypeJSON)
+		if err != nil {
+			return fmt.Errorf("failed to serialize genesis state: %w", err)
+		}
+
+		if err := os.WriteFile(jsonOutputFile, jsonData, 0o644); err != nil { //nolint:gosec // no strict permissions needed
+			return fmt.Errorf("failed to write genesis state to JSON file: %w", err)
+		}
+
+		if !quiet {
+			fmt.Printf("serialized genesis state to JSON file: %s\n", jsonOutputFile)
+		}
+	}
+
+	if stateOutputFile == "" && jsonOutputFile == "" {
+		jsonData, err := builder.Serialize(genesisState, http.ContentTypeJSON)
+		if err != nil {
+			return fmt.Errorf("failed to serialize genesis state: %w", err)
+		}
+
+		fmt.Println(string(jsonData))
+	}
+
+	return nil
+}

--- a/cmd/eth-genesis-state-generator/leanchain.go
+++ b/cmd/eth-genesis-state-generator/leanchain.go
@@ -1,0 +1,115 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/attestantio/go-eth2-client/http"
+	"github.com/ethpandaops/eth-beacon-genesis/buildinfo"
+	"github.com/ethpandaops/eth-beacon-genesis/eth1"
+	"github.com/ethpandaops/eth-beacon-genesis/leanchain"
+	"github.com/ethpandaops/eth-beacon-genesis/leanconfig"
+	"github.com/ethpandaops/eth-beacon-genesis/leanvalidators"
+	"github.com/sirupsen/logrus"
+	"github.com/urfave/cli/v3"
+)
+
+func runLeanchain(ctx context.Context, cmd *cli.Command) error {
+	eth1Config := cmd.String(eth1ConfigFlag.Name)
+	eth2Config := cmd.String(configFlag.Name)
+	validatorsFile := cmd.String(validatorsFileFlag.Name)
+	stateOutputFile := cmd.String(stateOutputFlag.Name)
+	jsonOutputFile := cmd.String(jsonOutputFlag.Name)
+	quiet := cmd.Bool(quietFlag.Name)
+
+	if quiet {
+		logrus.SetLevel(logrus.PanicLevel)
+	}
+
+	if !quiet {
+		logrus.Infof("eth-beacon-genesis version: %s", buildinfo.GetBuildVersion())
+	}
+
+	elGenesis, err := eth1.LoadEth1GenesisConfig(eth1Config)
+	if err != nil {
+		return fmt.Errorf("failed to load execution genesis: %w", err)
+	}
+
+	logrus.Infof("loaded execution genesis. chainid: %v", elGenesis.Config.ChainID.String())
+
+	clConfig, err := leanconfig.LoadConfig(eth2Config)
+	if err != nil {
+		return fmt.Errorf("failed to load consensus config: %w", err)
+	}
+
+	logrus.Infof("loaded leanchain config.")
+
+	var clValidators []*leanvalidators.Validator
+
+	if validatorsFile != "" {
+		vals, err2 := leanvalidators.LoadValidatorsFromFile(validatorsFile)
+		if err2 != nil {
+			return fmt.Errorf("failed to load validators from file: %w", err2)
+		}
+
+		if len(vals) > 0 {
+			clValidators = append(clValidators, vals...)
+		}
+	}
+
+	if len(clValidators) == 0 {
+		return fmt.Errorf("no validators found")
+	}
+
+	logrus.Infof("loaded %d validators.", len(clValidators))
+
+	builder := leanchain.NewGenesisBuilder(elGenesis, clConfig)
+	builder.AddValidators(clValidators)
+
+	genesisState, err := builder.BuildState()
+	if err != nil {
+		return fmt.Errorf("failed to build genesis: %w", err)
+	}
+
+	logrus.Infof("successfully built genesis state.")
+
+	if stateOutputFile != "" {
+		sszData, err := builder.Serialize(genesisState, http.ContentTypeSSZ)
+		if err != nil {
+			return fmt.Errorf("failed to serialize genesis state: %w", err)
+		}
+
+		if err := os.WriteFile(stateOutputFile, sszData, 0o644); err != nil { //nolint:gosec // no strict permissions needed
+			return fmt.Errorf("failed to write genesis state to SSZ file: %w", err)
+		}
+
+		logrus.Infof("serialized genesis state to SSZ file: %s", stateOutputFile)
+	}
+
+	if jsonOutputFile != "" {
+		jsonData, err := builder.Serialize(genesisState, http.ContentTypeJSON)
+		if err != nil {
+			return fmt.Errorf("failed to serialize genesis state: %w", err)
+		}
+
+		if err := os.WriteFile(jsonOutputFile, jsonData, 0o644); err != nil { //nolint:gosec // no strict permissions needed
+			return fmt.Errorf("failed to write genesis state to JSON file: %w", err)
+		}
+
+		if !quiet {
+			fmt.Printf("serialized genesis state to JSON file: %s\n", jsonOutputFile)
+		}
+	}
+
+	if stateOutputFile == "" && jsonOutputFile == "" {
+		jsonData, err := builder.Serialize(genesisState, http.ContentTypeJSON)
+		if err != nil {
+			return fmt.Errorf("failed to serialize genesis state: %w", err)
+		}
+
+		fmt.Println(string(jsonData))
+	}
+
+	return nil
+}

--- a/cmd/eth-genesis-state-generator/main.go
+++ b/cmd/eth-genesis-state-generator/main.go
@@ -6,16 +6,9 @@ import (
 	"log"
 	"os"
 
-	"github.com/attestantio/go-eth2-client/http"
-	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli/v3"
 
-	"github.com/ethpandaops/eth-beacon-genesis/beaconchain"
-	"github.com/ethpandaops/eth-beacon-genesis/beaconconfig"
 	"github.com/ethpandaops/eth-beacon-genesis/buildinfo"
-	"github.com/ethpandaops/eth-beacon-genesis/eth1"
-	"github.com/ethpandaops/eth-beacon-genesis/validators"
 )
 
 var (
@@ -73,8 +66,19 @@ var (
 					shadowForkBlockFlag, shadowForkRPCFlag, stateOutputFlag, jsonOutputFlag,
 					quietFlag,
 				},
-				Action:    runDevnet,
+				Action:    runBeaconchain,
 				UsageText: "eth-beacon-genesis beaconchain [options]",
+			},
+			{
+				Name:    "leanchain",
+				Usage:   "Generate a leanchain genesis state",
+				Aliases: []string{"lc", "lean", "leanchain"},
+				Flags: []cli.Flag{
+					eth1ConfigFlag, configFlag, validatorsFileFlag, stateOutputFlag, jsonOutputFlag,
+					quietFlag,
+				},
+				Action:    runLeanchain,
+				UsageText: "eth-beacon-genesis leanchain [options]",
 			},
 			{
 				Name:  "version",
@@ -94,154 +98,4 @@ func main() {
 	if err := app.Run(context.Background(), os.Args); err != nil {
 		log.Fatal(err)
 	}
-}
-
-func runDevnet(ctx context.Context, cmd *cli.Command) error {
-	eth1Config := cmd.String(eth1ConfigFlag.Name)
-	eth2Config := cmd.String(configFlag.Name)
-	mnemonicsFile := cmd.String(mnemonicsFileFlag.Name)
-	validatorsFile := cmd.String(validatorsFileFlag.Name)
-	shadowForkBlock := cmd.String(shadowForkBlockFlag.Name)
-	shadowForkRPC := cmd.String(shadowForkRPCFlag.Name)
-	stateOutputFile := cmd.String(stateOutputFlag.Name)
-	jsonOutputFile := cmd.String(jsonOutputFlag.Name)
-	quiet := cmd.Bool(quietFlag.Name)
-
-	if quiet {
-		logrus.SetLevel(logrus.PanicLevel)
-	}
-
-	if !quiet {
-		logrus.Infof("eth-beacon-genesis version: %s", buildinfo.GetBuildVersion())
-	}
-
-	elGenesis, err := eth1.LoadEth1GenesisConfig(eth1Config)
-	if err != nil {
-		return fmt.Errorf("failed to load execution genesis: %w", err)
-	}
-
-	logrus.Infof("loaded execution genesis. chainid: %v", elGenesis.Config.ChainID.String())
-
-	clConfig, err := beaconconfig.LoadConfig(eth2Config)
-	if err != nil {
-		return fmt.Errorf("failed to load consensus config: %w", err)
-	}
-
-	logrus.Infof("loaded consensus config. genesis fork version: 0x%x", clConfig.GetBytesDefault("GENESIS_FORK_VERSION", []byte{}))
-
-	var clValidators []*validators.Validator
-
-	if mnemonicsFile != "" {
-		vals, err2 := validators.GenerateValidatorsByMnemonic(mnemonicsFile)
-		if err2 != nil {
-			return fmt.Errorf("failed to load validators from mnemonics file: %w", err2)
-		}
-
-		if len(vals) > 0 {
-			clValidators = vals
-		}
-	}
-
-	if validatorsFile != "" {
-		vals, err2 := validators.LoadValidatorsFromFile(validatorsFile)
-		if err2 != nil {
-			return fmt.Errorf("failed to load validators from file: %w", err2)
-		}
-
-		if len(vals) > 0 {
-			clValidators = append(clValidators, vals...)
-		}
-	}
-
-	if len(clValidators) == 0 {
-		return fmt.Errorf("no validators found")
-	}
-
-	defaultBalance := clConfig.GetUintDefault("MAX_EFFECTIVE_BALANCE", 32_000_000_000)
-	totalBalance := uint64(0)
-
-	for _, val := range clValidators {
-		if val.Balance != nil {
-			totalBalance += *val.Balance
-		} else {
-			totalBalance += defaultBalance
-		}
-	}
-
-	logrus.Infof("loaded %d validators. total balance: %d ETH", len(clValidators), totalBalance/1_000_000_000)
-
-	builder := beaconchain.NewGenesisBuilder(elGenesis, clConfig)
-	builder.AddValidators(clValidators)
-
-	if shadowForkBlock != "" || shadowForkRPC != "" {
-		var gensisBlock *types.Block
-
-		if shadowForkBlock != "" {
-			block, err2 := eth1.LoadBlockFromFile(shadowForkBlock)
-			if err2 != nil {
-				return fmt.Errorf("failed to load shadow fork block from file: %w", err2)
-			}
-
-			logrus.Infof("loaded shadow fork block from file. hash: %s", block.Hash().String())
-
-			gensisBlock = block
-		} else {
-			block, err2 := eth1.GetBlockFromRPC(ctx, shadowForkRPC)
-			if err2 != nil {
-				return fmt.Errorf("failed to get shadow fork block: %w", err2)
-			}
-
-			logrus.Infof("loaded shadow fork block from RPC. hash: %s", block.Hash().String())
-
-			gensisBlock = block
-		}
-
-		builder.SetShadowForkBlock(gensisBlock)
-	}
-
-	genesisState, err := builder.BuildState()
-	if err != nil {
-		return fmt.Errorf("failed to build genesis: %w", err)
-	}
-
-	logrus.Infof("successfully built genesis state.")
-
-	if stateOutputFile != "" {
-		sszData, err := builder.Serialize(genesisState, http.ContentTypeSSZ)
-		if err != nil {
-			return fmt.Errorf("failed to serialize genesis state: %w", err)
-		}
-
-		if err := os.WriteFile(stateOutputFile, sszData, 0o644); err != nil { //nolint:gosec // no strict permissions needed
-			return fmt.Errorf("failed to write genesis state to SSZ file: %w", err)
-		}
-
-		logrus.Infof("serialized genesis state to SSZ file: %s", stateOutputFile)
-	}
-
-	if jsonOutputFile != "" {
-		jsonData, err := builder.Serialize(genesisState, http.ContentTypeJSON)
-		if err != nil {
-			return fmt.Errorf("failed to serialize genesis state: %w", err)
-		}
-
-		if err := os.WriteFile(jsonOutputFile, jsonData, 0o644); err != nil { //nolint:gosec // no strict permissions needed
-			return fmt.Errorf("failed to write genesis state to JSON file: %w", err)
-		}
-
-		if !quiet {
-			fmt.Printf("serialized genesis state to JSON file: %s\n", jsonOutputFile)
-		}
-	}
-
-	if stateOutputFile == "" && jsonOutputFile == "" {
-		jsonData, err := builder.Serialize(genesisState, http.ContentTypeJSON)
-		if err != nil {
-			return fmt.Errorf("failed to serialize genesis state: %w", err)
-		}
-
-		fmt.Println(string(jsonData))
-	}
-
-	return nil
 }

--- a/coreutils/convert.go
+++ b/coreutils/convert.go
@@ -1,4 +1,4 @@
-package beaconutils
+package coreutils
 
 import "encoding/binary"
 

--- a/coreutils/convert_test.go
+++ b/coreutils/convert_test.go
@@ -1,4 +1,4 @@
-package beaconutils
+package coreutils
 
 import (
 	"testing"

--- a/coreutils/fastssz.go
+++ b/coreutils/fastssz.go
@@ -1,4 +1,4 @@
-package beaconutils
+package coreutils
 
 import ssz "github.com/ferranbt/fastssz"
 

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.24.0
 require (
 	github.com/attestantio/go-eth2-client v0.26.0
 	github.com/ethereum/go-ethereum v1.16.2
+	github.com/ethpandaops/go-lean-types v0.0.0-20250813191016-ef475651d67a
 	github.com/ferranbt/fastssz v1.0.0
 	github.com/herumi/bls-eth-go-binary v1.36.4
 	github.com/holiman/uint256 v1.3.2
@@ -84,3 +85,5 @@ require (
 )
 
 replace github.com/attestantio/go-eth2-client => github.com/attestantio/go-eth2-client v0.0.0-20250721122214-dc2928832acc
+
+replace github.com/ethpandaops/go-lean-types => ../go-lean-types

--- a/leanchain/generator.go
+++ b/leanchain/generator.go
@@ -1,0 +1,23 @@
+package leanchain
+
+import (
+	"github.com/attestantio/go-eth2-client/http"
+	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/core/types"
+
+	"github.com/ethpandaops/eth-beacon-genesis/leanconfig"
+	"github.com/ethpandaops/eth-beacon-genesis/leanvalidators"
+)
+
+type NewLeanGenesisBuilderFn func(elGenesis *core.Genesis, clConfig *leanconfig.Config) LeanGenesisBuilder
+
+type LeanGenesisBuilder interface {
+	SetShadowForkBlock(block *types.Block)
+	AddValidators(validators []*leanvalidators.Validator)
+	BuildState() (any, error)
+	Serialize(state any, contentType http.ContentType) ([]byte, error)
+}
+
+func NewGenesisBuilder(elGenesis *core.Genesis, clConfig *leanconfig.Config) LeanGenesisBuilder {
+	return NewPhase0Builder(elGenesis, clConfig)
+}

--- a/leanchain/phase0.go
+++ b/leanchain/phase0.go
@@ -1,0 +1,70 @@
+package leanchain
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/attestantio/go-eth2-client/http"
+	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethpandaops/go-lean-types/specs/phase0"
+	"github.com/sirupsen/logrus"
+
+	"github.com/ethpandaops/eth-beacon-genesis/leanconfig"
+	"github.com/ethpandaops/eth-beacon-genesis/leanutils"
+	"github.com/ethpandaops/eth-beacon-genesis/leanvalidators"
+	dynssz "github.com/pk910/dynamic-ssz"
+)
+
+type phase0Builder struct {
+	elGenesis       *core.Genesis
+	clConfig        *leanconfig.Config
+	dynSsz          *dynssz.DynSsz
+	shadowForkBlock *types.Block
+	validators      []*leanvalidators.Validator
+}
+
+func NewPhase0Builder(elGenesis *core.Genesis, clConfig *leanconfig.Config) LeanGenesisBuilder {
+	return &phase0Builder{
+		elGenesis: elGenesis,
+		clConfig:  clConfig,
+		dynSsz:    leanutils.GetDynSSZ(clConfig),
+	}
+}
+
+func (b *phase0Builder) SetShadowForkBlock(block *types.Block) {
+	b.shadowForkBlock = block
+}
+
+func (b *phase0Builder) AddValidators(val []*leanvalidators.Validator) {
+	b.validators = append(b.validators, val...)
+}
+
+func (b *phase0Builder) BuildState() (any, error) {
+	genesisState := &phase0.State{
+		Config: phase0.Config{
+			NumValidators: uint64(len(b.validators)),
+		},
+		LatestJustified:          phase0.Checkpoint{},
+		LatestFinalized:          phase0.Checkpoint{},
+		HistoricalBlockHashes:    []phase0.Root{},
+		JustifiedSlots:           []bool{},
+		JustificationsRoots:      []phase0.Root{},
+		JustificationsValidators: []byte{},
+	}
+
+	logrus.Infof("genesis version: phase0")
+
+	return genesisState, nil
+}
+
+func (b *phase0Builder) Serialize(state any, contentType http.ContentType) ([]byte, error) {
+	switch contentType {
+	case http.ContentTypeSSZ:
+		return b.dynSsz.MarshalSSZ(state)
+	case http.ContentTypeJSON:
+		return json.Marshal(state)
+	default:
+		return nil, fmt.Errorf("unsupported content type: %s", contentType)
+	}
+}

--- a/leanconfig/config.go
+++ b/leanconfig/config.go
@@ -1,0 +1,178 @@
+package leanconfig
+
+import (
+	"encoding/binary"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/ethpandaops/eth-beacon-genesis/leanconfig/presets"
+)
+
+type Config struct {
+	values map[string]interface{}
+	preset map[string]interface{}
+}
+
+func LoadConfig(path string) (*Config, error) {
+	config := &Config{
+		values: make(map[string]interface{}),
+		preset: make(map[string]interface{}),
+	}
+
+	// load config from yaml
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("reading config file: %w", err)
+	}
+
+	values := make(map[string]interface{})
+	if err := yaml.Unmarshal(data, &values); err != nil {
+		return nil, fmt.Errorf("parsing yaml: %w", err)
+	}
+
+	for key, val := range values {
+		switch value := val.(type) {
+		case int:
+			if strings.HasSuffix(key, "_FORK_VERSION") {
+				// convert to big endian byte array
+				bytes := make([]byte, 4)
+				binary.BigEndian.PutUint32(bytes, uint32(value)) //nolint:gosec // ignore overflow
+				config.values[key] = bytes
+			} else {
+				config.values[key] = uint64(value) //nolint:gosec // ignore overflow
+			}
+		case uint64:
+			config.values[key] = value
+		case string:
+			if strings.HasPrefix(value, "0x") {
+				bytes, err := hex.DecodeString(strings.ReplaceAll(value, "0x", ""))
+				if err != nil {
+					return nil, fmt.Errorf("decoding hex: %w", err)
+				}
+
+				config.values[key] = bytes
+			} else if val, err := strconv.ParseUint(value, 10, 64); err == nil {
+				config.values[key] = val
+			} else {
+				config.values[key] = value
+			}
+		}
+	}
+
+	// load referenced preset
+	presetName, found := config.GetString("PRESET_BASE")
+	if found && presetName != "" {
+		presetData, err := presets.PresetsFS.ReadFile(presetName + ".yaml")
+		if err != nil {
+			return nil, fmt.Errorf("preset '%v' not found: %w", presetName, err)
+		}
+
+		presetMap := make(map[string]string)
+		if err := yaml.Unmarshal(presetData, &presetMap); err != nil {
+			return nil, fmt.Errorf("failed to parse preset yaml: %w", err)
+		}
+
+		for key, value := range presetMap {
+			if strings.HasPrefix(value, "0x") {
+				bytes, err := hex.DecodeString(strings.ReplaceAll(value, "0x", ""))
+				if err != nil {
+					return nil, fmt.Errorf("decoding hex: %w", err)
+				}
+
+				config.preset[key] = bytes
+			} else if val, err := strconv.ParseUint(value, 10, 64); err == nil {
+				config.preset[key] = val
+			} else {
+				config.preset[key] = value
+			}
+		}
+	}
+
+	return config, nil
+}
+
+func (c *Config) Get(key string) (interface{}, bool) {
+	value, ok := c.values[key]
+
+	if !ok {
+		value, ok = c.preset[key]
+	}
+
+	return value, ok
+}
+
+func (c *Config) GetString(key string) (string, bool) {
+	value, ok := c.Get(key)
+	if !ok {
+		return "", false
+	}
+
+	if str, ok := value.(string); ok {
+		return str, true
+	}
+
+	return "", false
+}
+
+func (c *Config) GetUint(key string) (uint64, bool) {
+	value, ok := c.Get(key)
+	if !ok {
+		return 0, false
+	}
+
+	if val, ok := value.(uint64); ok {
+		return val, true
+	}
+
+	return 0, false
+}
+
+func (c *Config) GetUintDefault(key string, defaultVal uint64) uint64 {
+	value, ok := c.GetUint(key)
+	if !ok {
+		return defaultVal
+	}
+
+	return value
+}
+
+func (c *Config) GetBytes(key string) ([]byte, bool) {
+	value, ok := c.Get(key)
+	if !ok {
+		return nil, false
+	}
+
+	if bytes, ok := value.([]byte); ok {
+		return bytes, true
+	}
+
+	return nil, false
+}
+
+func (c *Config) GetBytesDefault(key string, defaultVal []byte) []byte {
+	value, ok := c.GetBytes(key)
+	if !ok {
+		return defaultVal
+	}
+
+	return value
+}
+
+func (c *Config) GetSpecs() map[string]interface{} {
+	specs := make(map[string]interface{})
+
+	for k, v := range c.preset {
+		specs[k] = v
+	}
+
+	for k, v := range c.values {
+		specs[k] = v
+	}
+
+	return specs
+}

--- a/leanconfig/presets/mainnet.yaml
+++ b/leanconfig/presets/mainnet.yaml
@@ -1,0 +1,8 @@
+# Leanchain mainnet preset
+
+# Phase0
+# ---------------------------------------------------------------
+# uint64(2**18)
+HISTORICAL_ROOTS_LIMIT: 262144
+# uint64(2**12)
+VALIDATOR_REGISTRY_LIMIT: 4096

--- a/leanconfig/presets/minimal.yaml
+++ b/leanconfig/presets/minimal.yaml
@@ -1,0 +1,8 @@
+# Leanchain minimal preset
+
+# Phase0
+# ---------------------------------------------------------------
+# uint64(2**18)
+HISTORICAL_ROOTS_LIMIT: 262144
+# uint64(2**12)
+VALIDATOR_REGISTRY_LIMIT: 4096

--- a/leanconfig/presets/presets.go
+++ b/leanconfig/presets/presets.go
@@ -1,0 +1,10 @@
+package presets
+
+import (
+	"embed"
+)
+
+// preset configs
+//
+//go:embed *.yaml
+var PresetsFS embed.FS

--- a/leanutils/dynssz.go
+++ b/leanutils/dynssz.go
@@ -1,0 +1,13 @@
+package leanutils
+
+import (
+	"github.com/ethpandaops/eth-beacon-genesis/leanconfig"
+	dynssz "github.com/pk910/dynamic-ssz"
+)
+
+func GetDynSSZ(cfg *leanconfig.Config) *dynssz.DynSsz {
+	spec := cfg.GetSpecs()
+	dynSsz := dynssz.NewDynSsz(spec)
+
+	return dynSsz
+}

--- a/leanvalidators/list.go
+++ b/leanvalidators/list.go
@@ -1,0 +1,63 @@
+package leanvalidators
+
+import (
+	"bufio"
+	"os"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+func LoadValidatorsFromFile(validatorsConfigPath string) ([]*Validator, error) {
+	validatorsFile, err := os.Open(validatorsConfigPath)
+	if err != nil {
+		return nil, err
+	}
+
+	defer validatorsFile.Close()
+
+	validators := make([]*Validator, 0)
+
+	scanner := bufio.NewScanner(validatorsFile)
+	lineNum := 0
+
+	for scanner.Scan() {
+		line := scanner.Text()
+		lineNum++
+
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+
+		validatorEntry := &Validator{
+			ENR: line,
+		}
+
+		validators = append(validators, validatorEntry)
+	}
+
+	return validators, nil
+}
+
+func LoadValidatorsFromYaml(validatorsConfigPath string) ([]*Validator, error) {
+	validatorsFile, err := os.ReadFile(validatorsConfigPath)
+	if err != nil {
+		return nil, err
+	}
+
+	validators := make([]*Validator, 0)
+
+	validatorList := []string{}
+	err = yaml.Unmarshal(validatorsFile, &validatorList)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, validator := range validatorList {
+		validators = append(validators, &Validator{
+			ENR: validator,
+		})
+	}
+
+	return validators, nil
+}

--- a/leanvalidators/list_test.go
+++ b/leanvalidators/list_test.go
@@ -1,0 +1,71 @@
+package leanvalidators
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func createTestValidatorsFile(t *testing.T, data string) string {
+	t.Helper()
+	dir := t.TempDir()
+
+	validatorsFile, err := os.Create(filepath.Join(dir, "validators.txt"))
+	if err != nil {
+		t.Fatalf("failed to create validators file: %v", err)
+	}
+
+	_, err = validatorsFile.WriteString(data)
+	if err != nil {
+		t.Fatalf("failed to write validators data: %v", err)
+	}
+
+	return validatorsFile.Name()
+}
+
+func TestLoadValidatorsFromFile_Valid(t *testing.T) {
+	validatorsFile := createTestValidatorsFile(t, `
+# <ENR>
+enr:-Ku4QHqVeJ8PPICcWk1vSn_XcSkjOkNiTg6Fmii5j6vUQgvzMc9L1goFnLKgXqBJspJjIsB91LTOleFmyWWrFVATGngBh2F0dG5ldHOIAAAAAAAAAACEZXRoMpC1MD8qAAAAAP__________gmlkgnY0gmlwhAMRHkWJc2VjcDI1NmsxoQKLVXFOhp2uX6jeT0DvvDpPcU8FWMjQdR4wMuORMhpX24N1ZHCCIyg
+enr:-Ku4QPn5eVhcoF1opaFEvg1b6JNFD2rqVkHQ8HApOKK61OIcIXD127bKWgAtbwI7pnxx6cDyk_nI88TrZKQaGMZj0q0Bh2F0dG5ldHOIAAAAAAAAAACEZXRoMpC1MD8qAAAAAP__________gmlkgnY0gmlwhDayLMaJc2VjcDI1NmsxoQK2sBOLGcUb4AwuYzFuAVCaNHA-dy24UuEKkeFNgCVCsIN1ZHCCIyg
+enr:-Ku4QG-2_Md3sZIAUebGYT6g0SMskIml77l6yR-M_JXc-UdNHCmHQeOiMLbylPejyJsdAPsTHJyjJB2sYGDLe0dn8uYBh2F0dG5ldHOIAAAAAAAAAACEZXRoMpC1MD8qAAAAAP__________gmlkgnY0gmlwhBLY-NyJc2VjcDI1NmsxoQORcM6e19T1T9gi7jxEZjk_sjVLGFscUNqAY9obgZaxbIN1ZHCCIyg
+`)
+
+	validators, err := LoadValidatorsFromFile(validatorsFile)
+	if err != nil {
+		t.Fatalf("failed to load validators: %v", err)
+	}
+
+	if len(validators) != 3 {
+		t.Fatalf("expected 3 validators, got %d", len(validators))
+	}
+
+	// Validator 0
+	if validators[0].ENR != "enr:-Ku4QHqVeJ8PPICcWk1vSn_XcSkjOkNiTg6Fmii5j6vUQgvzMc9L1goFnLKgXqBJspJjIsB91LTOleFmyWWrFVATGngBh2F0dG5ldHOIAAAAAAAAAACEZXRoMpC1MD8qAAAAAP__________gmlkgnY0gmlwhAMRHkWJc2VjcDI1NmsxoQKLVXFOhp2uX6jeT0DvvDpPcU8FWMjQdR4wMuORMhpX24N1ZHCCIyg" {
+		t.Fatalf("expected validator 0 to have ENR enr:-Ku4QHqVeJ8PPICcWk1vSn_XcSkjOkNiTg6Fmii5j6vUQgvzMc9L1goFnLKgXqBJspJjIsB91LTOleFmyWWrFVATGngBh2F0dG5ldHOIAAAAAAAAAACEZXRoMpC1MD8qAAAAAP__________gmlkgnY0gmlwhAMRHkWJc2VjcDI1NmsxoQKLVXFOhp2uX6jeT0DvvDpPcU8FWMjQdR4wMuORMhpX24N1ZHCCIyg, got %s", validators[0].ENR)
+	}
+
+	// Validator 1
+	if validators[1].ENR != "enr:-Ku4QPn5eVhcoF1opaFEvg1b6JNFD2rqVkHQ8HApOKK61OIcIXD127bKWgAtbwI7pnxx6cDyk_nI88TrZKQaGMZj0q0Bh2F0dG5ldHOIAAAAAAAAAACEZXRoMpC1MD8qAAAAAP__________gmlkgnY0gmlwhDayLMaJc2VjcDI1NmsxoQK2sBOLGcUb4AwuYzFuAVCaNHA-dy24UuEKkeFNgCVCsIN1ZHCCIyg" {
+		t.Fatalf("expected validator 1 to have ENR enr:-Ku4QPn5eVhcoF1opaFEvg1b6JNFD2rqVkHQ8HApOKK61OIcIXD127bKWgAtbwI7pnxx6cDyk_nI88TrZKQaGMZj0q0Bh2F0dG5ldHOIAAAAAAAAAACEZXRoMpC1MD8qAAAAAP__________gmlkgnY0gmlwhDayLMaJc2VjcDI1NmsxoQK2sBOLGcUb4AwuYzFuAVCaNHA-dy24UuEKkeFNgCVCsIN1ZHCCIyg, got %s", validators[1].ENR)
+	}
+
+	// Validator 2
+	if validators[2].ENR != "enr:-Ku4QG-2_Md3sZIAUebGYT6g0SMskIml77l6yR-M_JXc-UdNHCmHQeOiMLbylPejyJsdAPsTHJyjJB2sYGDLe0dn8uYBh2F0dG5ldHOIAAAAAAAAAACEZXRoMpC1MD8qAAAAAP__________gmlkgnY0gmlwhBLY-NyJc2VjcDI1NmsxoQORcM6e19T1T9gi7jxEZjk_sjVLGFscUNqAY9obgZaxbIN1ZHCCIyg" {
+		t.Fatalf("expected validator 2 to have ENR enr:-Ku4QG-2_Md3sZIAUebGYT6g0SMskIml77l6yR-M_JXc-UdNHCmHQeOiMLbylPejyJsdAPsTHJyjJB2sYGDLe0dn8uYBh2F0dG5ldHOIAAAAAAAAAACEZXRoMpC1MD8qAAAAAP__________gmlkgnY0gmlwhBLY-NyJc2VjcDI1NmsxoQORcM6e19T1T9gi7jxEZjk_sjVLGFscUNqAY9obgZaxbIN1ZHCCIyg, got %s", validators[2].ENR)
+	}
+}
+
+func TestLoadValidatorsFromFile_InvalidFile(t *testing.T) {
+	validatorsFile := createTestValidatorsFile(t, ``)
+
+	_, err := LoadValidatorsFromFile(validatorsFile + "invalid")
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+
+	if !strings.Contains(err.Error(), "no such file or directory") {
+		t.Fatalf("expected error to contain 'no such file or directory', got %s", err)
+	}
+}

--- a/leanvalidators/validators.go
+++ b/leanvalidators/validators.go
@@ -1,0 +1,5 @@
+package leanvalidators
+
+type Validator struct {
+	ENR string
+}


### PR DESCRIPTION
This PR adds support for building leanchain genesis states for pq-devnet-0.

Genesis state currently looks as simple as this:
```json
{
  "config": {
    "num_validators": 3
  },
  "latest_justified": {
    "root": "0x0000000000000000000000000000000000000000000000000000000000000000",
    "slot": "0"
  },
  "latest_finalized": {
    "root": "0x0000000000000000000000000000000000000000000000000000000000000000",
    "slot": "0"
  },
  "historical_block_hashes": [],
  "justified_slots": [],
  "justifications_roots": [],
  "justifications_validators": []
}
```