### PR TITLE
fix: add gloas preset parameters to minimal and mainnet presets

### DIFF
--- a/beaconconfig/presets/mainnet.yaml
+++ b/beaconconfig/presets/mainnet.yaml
@@ -227,3 +227,27 @@ KZG_COMMITMENTS_INCLUSION_PROOF_DEPTH: 4
 FIELD_ELEMENTS_PER_CELL: 64
 # 2**1 * FIELD_ELEMENTS_PER_BLOB (= 8,192)
 FIELD_ELEMENTS_PER_EXT_BLOB: 8192
+
+# Mainnet preset - Gloas
+
+# Misc
+# ---------------------------------------------------------------
+# 2**9 (= 512) validators
+PTC_SIZE: 512
+
+# Max operations per block
+# ---------------------------------------------------------------
+# 2**2 (= 4) attestations
+MAX_PAYLOAD_ATTESTATIONS: 4
+
+# State list lengths
+# ---------------------------------------------------------------
+# 2**40 (= 1,099,511,627,776) builder spots
+BUILDER_REGISTRY_LIMIT: 1099511627776
+# 2**20 (= 1,048,576) builder pending withdrawals
+BUILDER_PENDING_WITHDRAWALS_LIMIT: 1048576
+
+# Withdrawals processing
+# ---------------------------------------------------------------
+# 2**14 (= 16,384) builders
+MAX_BUILDERS_PER_WITHDRAWALS_SWEEP: 16384

--- a/beaconconfig/presets/minimal.yaml
+++ b/beaconconfig/presets/minimal.yaml
@@ -227,3 +227,27 @@ KZG_COMMITMENTS_INCLUSION_PROOF_DEPTH: 4
 FIELD_ELEMENTS_PER_CELL: 64
 # 2**1 * FIELD_ELEMENTS_PER_BLOB (= 8,192)
 FIELD_ELEMENTS_PER_EXT_BLOB: 8192
+
+# Minimal preset - Gloas
+
+# Misc
+# ---------------------------------------------------------------
+# [customized] 2**1 (= 2) validators
+PTC_SIZE: 2
+
+# Max operations per block
+# ---------------------------------------------------------------
+# 2**2 (= 4) attestations
+MAX_PAYLOAD_ATTESTATIONS: 4
+
+# State list lengths
+# ---------------------------------------------------------------
+# 2**40 (= 1,099,511,627,776) builder spots
+BUILDER_REGISTRY_LIMIT: 1099511627776
+# 2**20 (= 1,048,576) builder pending withdrawals
+BUILDER_PENDING_WITHDRAWALS_LIMIT: 1048576
+
+# Withdrawals processing
+# ---------------------------------------------------------------
+# [customized] 2**4 (= 16) builders
+MAX_BUILDERS_PER_WITHDRAWALS_SWEEP: 16


### PR DESCRIPTION
## Summary

- Add gloas preset section (PTC_SIZE, MAX_PAYLOAD_ATTESTATIONS, BUILDER_REGISTRY_LIMIT, BUILDER_PENDING_WITHDRAWALS_LIMIT, MAX_BUILDERS_PER_WITHDRAWALS_SWEEP) to both `minimal.yaml` and `mainnet.yaml`
- Fixes minimal preset genesis: `PTC_SIZE` was missing from preset files, so `GetUintDefault("PTC_SIZE", 512)` always used mainnet's value (512) instead of minimal's (2), producing a `ptcWindow` that was 97920 bytes too large

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [ ] Generate genesis with minimal preset and verify Lodestar can load it

🤖 Generated with [Claude Code](https://claude.com/claude-code)