### PR TITLE
fix(gloas): treat genesis as empty parent in payload bid

### DIFF
--- a/beaconchain/gloas.go
+++ b/beaconchain/gloas.go
@@ -167,7 +167,7 @@ func (b *gloasBuilder) BuildState() (*spec.VersionedBeaconState, error) {
 		ProposerLookahead:           proposers,
 		Builders:                    clBuilders,
 		LatestExecutionPayloadBid: &gloas.ExecutionPayloadBid{
-			BlockHash:             phase0.Hash32(genesisBlockHash),
+			ParentBlockHash:       phase0.Hash32(genesisBlockHash),
 			ExecutionRequestsRoot: executionRequestsRoot,
 		},
 		ExecutionPayloadAvailability: beaconutils.MakeAllOnesBitvector(blocksPerHistoricalRoot),

--- a/beaconchain/gloas.go
+++ b/beaconchain/gloas.go
@@ -85,7 +85,10 @@ func (b *gloasBuilder) BuildState() (*spec.VersionedBeaconState, error) {
 			SyncCommitteeBits: make([]byte, syncCommitteeMaskBytes),
 		},
 		SignedExecutionPayloadBid: &gloas.SignedExecutionPayloadBid{
-			Message:   &gloas.ExecutionPayloadBid{},
+			Message: &gloas.ExecutionPayloadBid{
+				ParentBlockHash:       phase0.Hash32(genesisBlockHash),
+				ExecutionRequestsRoot: executionRequestsRoot,
+			},
 			Signature: phase0.BLSSignature(make([]byte, 96)),
 		},
 		ParentExecutionRequests: emptyExecutionRequests,

--- a/beaconchain/gloas.go
+++ b/beaconchain/gloas.go
@@ -85,10 +85,7 @@ func (b *gloasBuilder) BuildState() (*spec.VersionedBeaconState, error) {
 			SyncCommitteeBits: make([]byte, syncCommitteeMaskBytes),
 		},
 		SignedExecutionPayloadBid: &gloas.SignedExecutionPayloadBid{
-			Message: &gloas.ExecutionPayloadBid{
-				ParentBlockHash:       phase0.Hash32(genesisBlockHash),
-				ExecutionRequestsRoot: executionRequestsRoot,
-			},
+			Message:   &gloas.ExecutionPayloadBid{},
 			Signature: phase0.BLSSignature(make([]byte, 96)),
 		},
 		ParentExecutionRequests: emptyExecutionRequests,


### PR DESCRIPTION
## Summary
- Zero the genesis state's `latest_execution_payload_bid.block_hash` and set its `parent_block_hash` to the eth1 genesis hash so the parent of slot 1 is correctly treated as empty per Gloas spec v1.7.0-alpha.5.

## The bug
Previously the Gloas genesis state was constructed with:
- `LatestBlockHash = genesisBlockHash`
- `LatestExecutionPayloadBid.BlockHash = genesisBlockHash`
- `LatestExecutionPayloadBid.ParentBlockHash = 0x0` (default, never set)

At slot 1 this caused both spec early-return paths to fall through:
- `process_parent_execution_payload`: `is_genesis_block = (parent_bid.block_hash == 0)` was False, and `is_parent_block_empty = (slot1_bid.parent_block_hash != parent_bid.block_hash)` was False.
- `process_withdrawals`: `is_genesis_block` False, `is_parent_block_empty` False.

So withdrawals were applied at slot 1 even though no payload had ever been delivered. It also violated the bid-chain invariant `state.latest_execution_payload_bid.parent_block_hash == state.latest_block_hash`, which the slot-1 bid assertion (`process_execution_payload_bid:1275`) depends on through the not-extend branch in `validator.md:197-200`.

## The fix
- `LatestExecutionPayloadBid.BlockHash` → `0x0` (zero). Triggers `is_genesis_block` short-circuit in `process_parent_execution_payload`.
- `LatestExecutionPayloadBid.ParentBlockHash` → `genesisBlockHash`. Restores the invariant with `LatestBlockHash` and lets the slot-1 builder's not-extend branch resolve `bid.parent_block_hash = parent_bid.parent_block_hash = genesisBlockHash = state.latest_block_hash`, so the bid assertion passes and the EL builder is asked to build on the real EL genesis block.

`LatestBlockHash` stays at `genesisBlockHash` (the actual EL head). The genesis block body's `SignedExecutionPayloadBid.Message` was already a zero-valued struct, so its block_hash already matches the state's bid.

Net effect at slot 1:
- `process_parent_execution_payload` returns early via `is_genesis_block`.
- `process_withdrawals` returns early via `is_parent_block_empty` (eth1_hash != 0).
- `process_execution_payload_bid` assertion passes.
- No withdrawals are processed at slot 1; the first slot to compute and apply withdrawals is slot 2.

## Test plan
- [ ] Build passes (`go build ./...`).
- [ ] Spin up a Gloas devnet from the regenerated genesis and confirm slot 1's payload contains `withdrawals: []`, with eligible withdrawals first appearing at slot 2.
- [ ] Confirm CL clients (lighthouse, teku, etc.) accept the genesis state and process slot 1 without rejecting the bid assertion.