### PR TITLE
feat: bump minimal PTC_SIZE to 16 and go-eth2-client to v0.1.1

### DIFF
--- a/beaconconfig/presets/minimal.yaml
+++ b/beaconconfig/presets/minimal.yaml
@@ -232,8 +232,8 @@ FIELD_ELEMENTS_PER_EXT_BLOB: 8192
 
 # Misc
 # ---------------------------------------------------------------
-# [customized] 2**1 (= 2) validators
-PTC_SIZE: 2
+# [customized] 2**4 (= 16) validators
+PTC_SIZE: 16
 
 # Max operations per block
 # ---------------------------------------------------------------

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/ethereum/go-ethereum v1.17.2
-	github.com/ethpandaops/go-eth2-client v0.1.0
+	github.com/ethpandaops/go-eth2-client v0.1.1
 	github.com/herumi/bls-eth-go-binary v1.37.0
 	github.com/holiman/uint256 v1.3.2
 	github.com/pk910/dynamic-ssz v1.3.1

--- a/go.sum
+++ b/go.sum
@@ -58,8 +58,8 @@ github.com/ethereum/go-bigmodexpfix v0.0.0-20250911101455-f9e208c548ab h1:rvv6MJ
 github.com/ethereum/go-bigmodexpfix v0.0.0-20250911101455-f9e208c548ab/go.mod h1:IuLm4IsPipXKF7CW5Lzf68PIbZ5yl7FFd74l/E0o9A8=
 github.com/ethereum/go-ethereum v1.17.3-0.20260421080339-499762852cf2 h1:PPbNu5NqmJ6+uo1y43tp1sBOt0a0S1gop5agy6qchMI=
 github.com/ethereum/go-ethereum v1.17.3-0.20260421080339-499762852cf2/go.mod h1:KHcRXfGOUfUmKg51IhQ0IowiqZ6PqZf08CMtk0g5K1o=
-github.com/ethpandaops/go-eth2-client v0.1.0 h1:migUQIIL3fcWWMmIwF4Rh05rvJPuj+LOgDJkIWZ+gIE=
-github.com/ethpandaops/go-eth2-client v0.1.0/go.mod h1:9BBd/XIw1egZTkxtFGMvgXnsxX6ypKHKNKD7itqjmNQ=
+github.com/ethpandaops/go-eth2-client v0.1.1 h1:+uaGtPiyjp8sb2K9cjeZpbHrRCu6yjHtlx4J8+bbA8U=
+github.com/ethpandaops/go-eth2-client v0.1.1/go.mod h1:qoj9ZVKydI99IuIyWt4EvGq4rGgMYfOy6q8zTtwYdy4=
 github.com/fatih/color v1.10.0/go.mod h1:ELkj/draVOlAH/xkhN6mQ50Qd0MPOk5AAr3maGEBuJM=
 github.com/fatih/color v1.18.0 h1:S8gINlzdQ840/4pfAwic/ZE0djQEH3wM94VfqLTZcOM=
 github.com/fatih/color v1.18.0/go.mod h1:4FelSpRwEGDpQ12mAdzqdOukCy4u8WUtOY6lkT/6HfU=


### PR DESCRIPTION
## Summary
- **Minimal preset PTC_SIZE: 2 → 16.** Matches consensus-specs alpha 6 ([#5177](https://github.com/ethereum/consensus-specs/pull/5177)) — minimal-preset Gloas devnets were emitting the wrong committee size from genesis.
- **Bump go-eth2-client v0.1.0 → v0.1.1.**

## Test plan
- [x] \`go build ./...\`
- [x] \`go test ./...\`
- [ ] Generate a minimal-preset Gloas genesis state and confirm \`ptc_window\` slots size to \`16\` validators each