### PR TITLE
fix: include block hash in Gloas genesis block

### DIFF
--- a/beaconchain/gloas.go
+++ b/beaconchain/gloas.go
@@ -85,7 +85,10 @@ func (b *gloasBuilder) BuildState() (*spec.VersionedBeaconState, error) {
 			SyncCommitteeBits: make([]byte, syncCommitteeMaskBytes),
 		},
 		SignedExecutionPayloadBid: &gloas.SignedExecutionPayloadBid{
-			Message:   &gloas.ExecutionPayloadBid{},
+			Message: &gloas.ExecutionPayloadBid{
+				ParentBlockHash:       phase0.Hash32(genesisBlockHash),
+				ExecutionRequestsRoot: executionRequestsRoot,
+			},
 			Signature: phase0.BLSSignature(make([]byte, 96)),
 		},
 		ParentExecutionRequests: emptyExecutionRequests,


### PR DESCRIPTION
Closes:

- https://github.com/ethpandaops/eth-beacon-genesis/issues/76