### PR TITLE
ci: auto-publish releases instead of creating drafts

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -80,7 +80,7 @@ jobs:
     - name: Create latest release
       uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2.6.1
       with:
-        draft: true
+        draft: false
         prerelease: false
         name: "v${{ inputs.version }}"
         tag_name: "v${{ inputs.version }}"


### PR DESCRIPTION
## Summary
- Flip `draft: true` → `draft: false` in `.github/workflows/build-release.yml` so releases triggered via `workflow_dispatch` are published automatically once the build completes, removing the manual "Publish" click in the GitHub Releases UI.

## Test plan
- [ ] Trigger the `Build Release` workflow with a test version and confirm the resulting GitHub release is published (not a draft).