### PR TITLE
add validator shuffling & mapping file

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,9 @@ eth-genesis-state-generator beaconchain \
 - `--additional-validators`: Path to file with additional genesis validators
 - `--state-output`: Output path for SSZ genesis state
 - `--json-output`: Output path for JSON genesis state
+- `--shuffle-validators`: Shuffle the validator set block-wise to add variance to the validator ordering
+- `--shuffle-seed`: Seed for the block-wise validator shuffle (defaults to the genesis fork version; only used with `--shuffle-validators`)
+- `--validators-mapping-output`: Output path for the validator mapping (state index ranges to source key ranges) in YAML format
 - `--quiet`: Suppress output
 
 ### Configuration Files
@@ -91,6 +94,7 @@ eth-genesis-state-generator beaconchain \
 #### Validator Mnemonics File
 ```yaml
 - mnemonic: ""                                             # a 24 word BIP 39 mnemonic
+  name: ""                                                 # optional source name used in the validator mapping (defaults to mnemonic-<index>)
   start: 0                                                 # account index to start from
   count: 100                                               # number of validators to generate
   balance: 32000000000                                     # effective balance

--- a/cmd/eth-genesis-state-generator/main.go
+++ b/cmd/eth-genesis-state-generator/main.go
@@ -54,6 +54,18 @@ var (
 		Name:  "json-output",
 		Usage: "Path to the file to write the genesis state to in JSON format",
 	}
+	shuffleValidatorsFlag = &cli.BoolFlag{
+		Name:  "shuffle-validators",
+		Usage: "Shuffle the validator set block-wise to add variance to the validator ordering",
+	}
+	shuffleSeedFlag = &cli.Uint64Flag{
+		Name:  "shuffle-seed",
+		Usage: "Seed for the block-wise validator shuffle (defaults to the genesis fork version; only used with --shuffle-validators)",
+	}
+	validatorsMappingOutputFlag = &cli.StringFlag{
+		Name:  "validators-mapping-output",
+		Usage: "Path to write the validator mapping (state index ranges to source key ranges) in YAML format",
+	}
 
 	quietFlag = &cli.BoolFlag{
 		Name:    "quiet",
@@ -72,6 +84,7 @@ var (
 				Flags: []cli.Flag{
 					eth1ConfigFlag, configFlag, mnemonicsFileFlag, validatorsFileFlag,
 					shadowForkBlockFlag, shadowForkRPCFlag, stateOutputFlag, jsonOutputFlag,
+					shuffleValidatorsFlag, shuffleSeedFlag, validatorsMappingOutputFlag,
 					quietFlag,
 				},
 				Action:    runDevnet,
@@ -107,6 +120,9 @@ func runDevnet(ctx context.Context, cmd *cli.Command) error {
 	shadowForkRPC := cmd.String(shadowForkRPCFlag.Name)
 	stateOutputFile := cmd.String(stateOutputFlag.Name)
 	jsonOutputFile := cmd.String(jsonOutputFlag.Name)
+	shuffleValidators := cmd.Bool(shuffleValidatorsFlag.Name)
+	shuffleSeed := cmd.Uint64(shuffleSeedFlag.Name)
+	validatorsMappingOutput := cmd.String(validatorsMappingOutputFlag.Name)
 	quiet := cmd.Bool(quietFlag.Name)
 
 	if quiet {
@@ -182,6 +198,23 @@ func runDevnet(ctx context.Context, cmd *cli.Command) error {
 	}
 
 	logrus.Infof("loaded %d validators. total balance: %d ETH", len(clValidators), totalBalance/1_000_000_000)
+
+	if shuffleValidators {
+		if !cmd.IsSet(shuffleSeedFlag.Name) {
+			shuffleSeed = validators.SeedFromForkVersion(clConfig.GetBytesDefault("GENESIS_FORK_VERSION", []byte{}))
+		}
+
+		validators.ShuffleValidators(clValidators, shuffleSeed)
+		logrus.Infof("shuffled validator set block-wise (seed: %d)", shuffleSeed)
+	}
+
+	if validatorsMappingOutput != "" {
+		if err := validators.WriteMappingFile(validatorsMappingOutput, clValidators); err != nil {
+			return fmt.Errorf("failed to write validator mapping: %w", err)
+		}
+
+		logrus.Infof("wrote validator mapping to: %s", validatorsMappingOutput)
+	}
 
 	builder := beaconchain.NewGenesisBuilder(elGenesis, clConfig)
 	builder.AddValidators(clValidators)

--- a/validators/list.go
+++ b/validators/list.go
@@ -12,6 +12,10 @@ import (
 	"github.com/ethpandaops/go-eth2-client/spec/phase0"
 )
 
+// fileSource is the Source tag assigned to validators loaded from the
+// additional-validators file.
+const fileSource = "additional-validators"
+
 func LoadValidatorsFromFile(validatorsConfigPath string) ([]*Validator, error) {
 	validatorsFile, err := os.Open(validatorsConfigPath)
 	if err != nil {
@@ -54,6 +58,8 @@ func LoadValidatorsFromFile(validatorsConfigPath string) ([]*Validator, error) {
 		validatorEntry := &Validator{
 			PublicKey:             phase0.BLSPubKey(pubKey),
 			WithdrawalCredentials: make([]byte, 32),
+			Source:                fileSource,
+			SourceKeyIndex:        uint64(len(validators)),
 		}
 
 		// Withdrawal credentials

--- a/validators/mapping.go
+++ b/validators/mapping.go
@@ -1,0 +1,86 @@
+package validators
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+// MappingEntry describes a contiguous range of validators in the final state
+// that originate from a single contiguous range of key indices within one
+// source. It is the in-memory representation of a single validator-mapping line.
+type MappingEntry struct {
+	// StateIndexFrom and StateIndexTo are the inclusive validator index range in
+	// the final genesis state.
+	StateIndexFrom uint64
+	StateIndexTo   uint64
+
+	// Source identifies where the keys originate (e.g. "mnemonic-0").
+	Source string
+
+	// KeyIndexFrom and KeyIndexTo are the inclusive key index range within the
+	// source.
+	KeyIndexFrom uint64
+	KeyIndexTo   uint64
+}
+
+// BuildMapping derives the validator mapping from the final, ordered validator
+// list. Consecutive validators that share a source and have contiguous key
+// indices are collapsed into a single entry, so a sequential (un-shuffled) set
+// produces one entry per source and a block-shuffled set produces one entry per
+// contiguous block.
+func BuildMapping(vals []*Validator) []MappingEntry {
+	entries := make([]MappingEntry, 0)
+	if len(vals) == 0 {
+		return entries
+	}
+
+	start := 0
+
+	for i := 1; i <= len(vals); i++ {
+		// A run continues while the next validator shares the source and its key
+		// index follows the previous one. The final iteration (i == len) always
+		// closes the open run.
+		continues := i < len(vals) &&
+			vals[i].Source == vals[start].Source &&
+			vals[i].SourceKeyIndex == vals[i-1].SourceKeyIndex+1
+
+		if continues {
+			continue
+		}
+
+		//nolint:gosec // start and i-1 are loop indices, always >= 0
+		entries = append(entries, MappingEntry{
+			StateIndexFrom: uint64(start),
+			StateIndexTo:   uint64(i - 1),
+			Source:         vals[start].Source,
+			KeyIndexFrom:   vals[start].SourceKeyIndex,
+			KeyIndexTo:     vals[i-1].SourceKeyIndex,
+		})
+
+		start = i
+	}
+
+	return entries
+}
+
+// WriteMappingFile writes the validator mapping to path as a YAML list, one
+// entry per line, in the form:
+//
+//   - <state-from>-<state-to>: { src: "<source>", from: <key-from>, to: <key-to> }
+func WriteMappingFile(path string, vals []*Validator) error {
+	entries := BuildMapping(vals)
+
+	var sb strings.Builder
+
+	for _, e := range entries {
+		fmt.Fprintf(&sb, "- %d-%d: { src: %q, from: %d, to: %d }\n",
+			e.StateIndexFrom, e.StateIndexTo, e.Source, e.KeyIndexFrom, e.KeyIndexTo)
+	}
+
+	if err := os.WriteFile(path, []byte(sb.String()), 0o644); err != nil { //nolint:gosec // no strict permissions needed
+		return fmt.Errorf("failed to write validator mapping file: %w", err)
+	}
+
+	return nil
+}

--- a/validators/mapping_test.go
+++ b/validators/mapping_test.go
@@ -45,11 +45,11 @@ func TestBuildMapping_RangesCoverAllAndStayContiguous(t *testing.T) {
 		t.Fatalf("expected the shuffle to produce multiple entries, got %d", len(entries))
 	}
 
-	covered := 0
+	var covered uint64
 
 	for i, e := range entries {
 		// State indices must be contiguous and cover the whole set.
-		if e.StateIndexFrom != uint64(covered) {
+		if e.StateIndexFrom != covered {
 			t.Fatalf("entry %d state range starts at %d, expected %d", i, e.StateIndexFrom, covered)
 		}
 
@@ -68,7 +68,7 @@ func TestBuildMapping_RangesCoverAllAndStayContiguous(t *testing.T) {
 				i, e.KeyIndexFrom, e.StateIndexFrom, vals[e.StateIndexFrom].SourceKeyIndex)
 		}
 
-		covered = int(e.StateIndexTo) + 1 //nolint:gosec // test indices are small
+		covered = e.StateIndexTo + 1
 	}
 
 	if covered != count {

--- a/validators/mapping_test.go
+++ b/validators/mapping_test.go
@@ -1,0 +1,98 @@
+package validators
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestBuildMapping_Sequential(t *testing.T) {
+	// Two sources concatenated sequentially collapse into one entry each.
+	vals := append(makeValidators("mnemonic-0", 50), makeValidators("additional-validators", 30)...)
+
+	entries := BuildMapping(vals)
+
+	if len(entries) != 2 {
+		t.Fatalf("expected 2 mapping entries, got %d", len(entries))
+	}
+
+	want := []MappingEntry{
+		{StateIndexFrom: 0, StateIndexTo: 49, Source: "mnemonic-0", KeyIndexFrom: 0, KeyIndexTo: 49},
+		{StateIndexFrom: 50, StateIndexTo: 79, Source: "additional-validators", KeyIndexFrom: 0, KeyIndexTo: 29},
+	}
+
+	for i, w := range want {
+		if entries[i] != w {
+			t.Fatalf("entry %d = %+v, want %+v", i, entries[i], w)
+		}
+	}
+}
+
+func TestBuildMapping_Empty(t *testing.T) {
+	if entries := BuildMapping(nil); len(entries) != 0 {
+		t.Fatalf("expected no entries for empty input, got %d", len(entries))
+	}
+}
+
+func TestBuildMapping_RangesCoverAllAndStayContiguous(t *testing.T) {
+	const count = 1000
+
+	vals := makeValidators("mnemonic-0", count)
+	ShuffleValidators(vals, 555)
+
+	entries := BuildMapping(vals)
+	if len(entries) < 2 {
+		t.Fatalf("expected the shuffle to produce multiple entries, got %d", len(entries))
+	}
+
+	covered := 0
+
+	for i, e := range entries {
+		// State indices must be contiguous and cover the whole set.
+		if e.StateIndexFrom != uint64(covered) {
+			t.Fatalf("entry %d state range starts at %d, expected %d", i, e.StateIndexFrom, covered)
+		}
+
+		stateLen := e.StateIndexTo - e.StateIndexFrom
+		keyLen := e.KeyIndexTo - e.KeyIndexFrom
+
+		// Each entry maps an equal-length state and key range (contiguous block).
+		if stateLen != keyLen {
+			t.Fatalf("entry %d state length %d != key length %d", i, stateLen, keyLen)
+		}
+
+		// The validator at the start of each state range must carry the entry's
+		// source key index.
+		if vals[e.StateIndexFrom].SourceKeyIndex != e.KeyIndexFrom {
+			t.Fatalf("entry %d key-from %d does not match validator at state %d (%d)",
+				i, e.KeyIndexFrom, e.StateIndexFrom, vals[e.StateIndexFrom].SourceKeyIndex)
+		}
+
+		covered = int(e.StateIndexTo) + 1 //nolint:gosec // test indices are small
+	}
+
+	if covered != count {
+		t.Fatalf("entries cover %d validators, expected %d", covered, count)
+	}
+}
+
+func TestWriteMappingFile(t *testing.T) {
+	vals := append(makeValidators("mnemonic-0", 20), makeValidators("additional-validators", 20)...)
+
+	path := filepath.Join(t.TempDir(), "mapping.yaml")
+	if err := WriteMappingFile(path, vals); err != nil {
+		t.Fatalf("WriteMappingFile failed: %v", err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("failed to read mapping file: %v", err)
+	}
+
+	want := "- 0-19: { src: \"mnemonic-0\", from: 0, to: 19 }\n" +
+		"- 20-39: { src: \"additional-validators\", from: 0, to: 19 }\n"
+
+	if string(data) != want {
+		t.Fatalf("unexpected mapping file content:\ngot:\n%s\nwant:\n%s", string(data), want)
+	}
+}

--- a/validators/mnemonic.go
+++ b/validators/mnemonic.go
@@ -47,6 +47,13 @@ func GenerateValidatorsByMnemonic(mnemonicsConfigPath string) ([]*Validator, err
 			return nil, fmt.Errorf("mnemonic %d is bad", m)
 		}
 
+		// Use the explicit name for the validator mapping if provided, otherwise
+		// fall back to the mnemonic's index in the list.
+		source := mnemonicSrc.Name
+		if source == "" {
+			source = fmt.Sprintf("mnemonic-%d", m)
+		}
+
 		for i := uint64(0); i < mnemonicSrc.Count; i++ {
 			valIndex := offset + i
 			idx := mnemonicSrc.Start + i
@@ -61,6 +68,8 @@ func GenerateValidatorsByMnemonic(mnemonicsConfigPath string) ([]*Validator, err
 					PublicKey:             phase0.BLSPubKey(signingSK.PublicKey().Marshal()),
 					WithdrawalCredentials: make([]byte, 32),
 					Status:                mnemonicSrc.Status,
+					Source:                source,
+					SourceKeyIndex:        idx,
 				}
 
 				if mnemonicSrc.WdPrefix != "" && mnemonicSrc.WdPrefix != "0x00" && mnemonicSrc.WdAddress != "" {
@@ -145,6 +154,7 @@ func seedFromMnemonic(mnemonic string) (seed []byte, err error) {
 
 type MnemonicSrc struct {
 	Mnemonic  string          `yaml:"mnemonic"`
+	Name      string          `yaml:"name"`
 	Start     uint64          `yaml:"start"`
 	Count     uint64          `yaml:"count"`
 	Balance   uint64          `yaml:"balance"`

--- a/validators/shuffle.go
+++ b/validators/shuffle.go
@@ -1,0 +1,97 @@
+package validators
+
+import (
+	"encoding/binary"
+	"math/rand/v2"
+)
+
+const (
+	// minBlockSize and maxBlockSize bound the size of a shuffle block. The
+	// validator list is split into contiguous blocks of this many validators
+	// and the blocks (not the individual validators) are reordered, preserving
+	// each block's internal ordering.
+	minBlockSize = 20
+	maxBlockSize = 100
+
+	// blockScaleDivisor controls how the block size scales with the total
+	// validator count: blockSize = totalCount / blockScaleDivisor, clamped to
+	// [minBlockSize, maxBlockSize]. Small sets use minBlockSize, large sets
+	// (>= maxBlockSize*blockScaleDivisor validators) use maxBlockSize.
+	blockScaleDivisor = 100
+
+	// DefaultShuffleSeed is the seed used for block shuffling when the user does
+	// not provide one. A fixed default keeps generation reproducible by default.
+	DefaultShuffleSeed uint64 = 0x6765_6e65_7369_73 // "genesis"
+)
+
+// SeedFromForkVersion derives a deterministic shuffle seed from the genesis
+// fork version. It is used when no explicit --shuffle-seed is provided, so the
+// ordering stays reproducible and tied to the network. Falls back to
+// DefaultShuffleSeed when the fork version is empty.
+func SeedFromForkVersion(forkVersion []byte) uint64 {
+	if len(forkVersion) == 0 {
+		return DefaultShuffleSeed
+	}
+
+	if len(forkVersion) > 8 {
+		forkVersion = forkVersion[len(forkVersion)-8:]
+	}
+
+	var buf [8]byte
+
+	copy(buf[8-len(forkVersion):], forkVersion)
+
+	return binary.BigEndian.Uint64(buf[:])
+}
+
+// blockSizeForCount returns the shuffle block size for a validator set of the
+// given size, scaling from minBlockSize (small sets) to maxBlockSize (large
+// sets) based on the total count.
+func blockSizeForCount(count int) int {
+	size := count / blockScaleDivisor
+
+	switch {
+	case size < minBlockSize:
+		return minBlockSize
+	case size > maxBlockSize:
+		return maxBlockSize
+	default:
+		return size
+	}
+}
+
+// ShuffleValidators reorders the validator list block-wise in place. The list
+// is split into contiguous blocks (see blockSizeForCount) and the order of the
+// blocks is shuffled using a PRNG seeded with seed, so the same inputs and seed
+// always produce the same ordering. Validators within a block keep their
+// relative order, which keeps the resulting mapping compact.
+func ShuffleValidators(vals []*Validator, seed uint64) {
+	n := len(vals)
+	if n <= minBlockSize {
+		// Nothing meaningful to shuffle: a single block (or less).
+		return
+	}
+
+	blockSize := blockSizeForCount(n)
+	blockCount := (n + blockSize - 1) / blockSize
+
+	order := make([]int, blockCount)
+	for i := range order {
+		order[i] = i
+	}
+
+	rng := rand.New(rand.NewPCG(seed, seed)) //nolint:gosec // deterministic shuffle, not security-sensitive
+	rng.Shuffle(blockCount, func(i, j int) {
+		order[i], order[j] = order[j], order[i]
+	})
+
+	shuffled := make([]*Validator, 0, n)
+
+	for _, block := range order {
+		start := block * blockSize
+		end := min(start+blockSize, n)
+		shuffled = append(shuffled, vals[start:end]...)
+	}
+
+	copy(vals, shuffled)
+}

--- a/validators/shuffle_test.go
+++ b/validators/shuffle_test.go
@@ -11,17 +11,22 @@ import (
 // sequential key indices, so tests can track where each ends up after shuffling.
 func makeValidators(source string, count int) []*Validator {
 	vals := make([]*Validator, count)
+
+	var keyIndex uint64
+
 	for i := range vals {
 		var pubkey phase0.BLSPubKey
 		// Encode the key index into the pubkey so order can be asserted.
-		pubkey[0] = byte(i)
-		pubkey[1] = byte(i >> 8)
+		pubkey[0] = byte(keyIndex)
+		pubkey[1] = byte(keyIndex >> 8)
 
 		vals[i] = &Validator{
 			PublicKey:      pubkey,
 			Source:         source,
-			SourceKeyIndex: uint64(i),
+			SourceKeyIndex: keyIndex,
 		}
+
+		keyIndex++
 	}
 
 	return vals
@@ -119,16 +124,20 @@ func TestShuffleValidators_PreservesSetAndChangesOrder(t *testing.T) {
 	seen := make(map[uint64]bool, count)
 	ordered := true
 
-	for i, v := range vals {
+	var idx uint64
+
+	for _, v := range vals {
 		if seen[v.SourceKeyIndex] {
 			t.Fatalf("duplicate key index %d after shuffle", v.SourceKeyIndex)
 		}
 
 		seen[v.SourceKeyIndex] = true
 
-		if uint64(i) != v.SourceKeyIndex {
+		if v.SourceKeyIndex != idx {
 			ordered = false
 		}
+
+		idx++
 	}
 
 	if len(seen) != count {
@@ -161,9 +170,13 @@ func TestShuffleValidators_SmallSetNoOp(t *testing.T) {
 	vals := makeValidators("mnemonic-0", minBlockSize)
 	ShuffleValidators(vals, 42)
 
-	for i, v := range vals {
-		if uint64(i) != v.SourceKeyIndex {
-			t.Fatalf("small set should not be shuffled, but index %d moved", i)
+	var idx uint64
+
+	for _, v := range vals {
+		if v.SourceKeyIndex != idx {
+			t.Fatalf("small set should not be shuffled, but index %d moved", idx)
 		}
+
+		idx++
 	}
 }

--- a/validators/shuffle_test.go
+++ b/validators/shuffle_test.go
@@ -1,0 +1,169 @@
+package validators
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/ethpandaops/go-eth2-client/spec/phase0"
+)
+
+// makeValidators builds count validators tagged with a single source and
+// sequential key indices, so tests can track where each ends up after shuffling.
+func makeValidators(source string, count int) []*Validator {
+	vals := make([]*Validator, count)
+	for i := range vals {
+		var pubkey phase0.BLSPubKey
+		// Encode the key index into the pubkey so order can be asserted.
+		pubkey[0] = byte(i)
+		pubkey[1] = byte(i >> 8)
+
+		vals[i] = &Validator{
+			PublicKey:      pubkey,
+			Source:         source,
+			SourceKeyIndex: uint64(i),
+		}
+	}
+
+	return vals
+}
+
+func TestSeedFromForkVersion(t *testing.T) {
+	tests := []struct {
+		name        string
+		forkVersion []byte
+		want        uint64
+	}{
+		{name: "empty", forkVersion: nil, want: DefaultShuffleSeed},
+		{name: "four-bytes", forkVersion: []byte{0x10, 0x00, 0x00, 0x38}, want: 0x10000038},
+		{name: "eight-bytes", forkVersion: []byte{1, 2, 3, 4, 5, 6, 7, 8}, want: 0x0102030405060708},
+		{name: "over-eight-bytes", forkVersion: []byte{0xff, 1, 2, 3, 4, 5, 6, 7, 8}, want: 0x0102030405060708},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := SeedFromForkVersion(tt.forkVersion); got != tt.want {
+				t.Fatalf("SeedFromForkVersion(%x) = %#x, want %#x", tt.forkVersion, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBlockSizeForCount(t *testing.T) {
+	tests := []struct {
+		count int
+		want  int
+	}{
+		{count: 0, want: minBlockSize},
+		{count: 100, want: minBlockSize},
+		{count: 2000, want: minBlockSize}, // 2000/100 = 20 = min
+		{count: 5000, want: 50},           // 5000/100 = 50
+		{count: 10000, want: maxBlockSize},
+		{count: 1_000_000, want: maxBlockSize},
+	}
+
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("count-%d", tt.count), func(t *testing.T) {
+			if got := blockSizeForCount(tt.count); got != tt.want {
+				t.Fatalf("blockSizeForCount(%d) = %d, want %d", tt.count, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestShuffleValidators_Deterministic(t *testing.T) {
+	a := makeValidators("mnemonic-0", 1000)
+	b := makeValidators("mnemonic-0", 1000)
+
+	ShuffleValidators(a, 12345)
+	ShuffleValidators(b, 12345)
+
+	for i := range a {
+		if a[i].SourceKeyIndex != b[i].SourceKeyIndex {
+			t.Fatalf("same seed produced different order at index %d: %d != %d",
+				i, a[i].SourceKeyIndex, b[i].SourceKeyIndex)
+		}
+	}
+}
+
+func TestShuffleValidators_DifferentSeed(t *testing.T) {
+	a := makeValidators("mnemonic-0", 1000)
+	b := makeValidators("mnemonic-0", 1000)
+
+	ShuffleValidators(a, 1)
+	ShuffleValidators(b, 2)
+
+	identical := true
+
+	for i := range a {
+		if a[i].SourceKeyIndex != b[i].SourceKeyIndex {
+			identical = false
+			break
+		}
+	}
+
+	if identical {
+		t.Fatal("different seeds produced the same order")
+	}
+}
+
+func TestShuffleValidators_PreservesSetAndChangesOrder(t *testing.T) {
+	const count = 1000
+
+	vals := makeValidators("mnemonic-0", count)
+	ShuffleValidators(vals, 999)
+
+	if len(vals) != count {
+		t.Fatalf("expected %d validators after shuffle, got %d", count, len(vals))
+	}
+
+	seen := make(map[uint64]bool, count)
+	ordered := true
+
+	for i, v := range vals {
+		if seen[v.SourceKeyIndex] {
+			t.Fatalf("duplicate key index %d after shuffle", v.SourceKeyIndex)
+		}
+
+		seen[v.SourceKeyIndex] = true
+
+		if uint64(i) != v.SourceKeyIndex {
+			ordered = false
+		}
+	}
+
+	if len(seen) != count {
+		t.Fatalf("expected %d unique validators, got %d", count, len(seen))
+	}
+
+	if ordered {
+		t.Fatal("shuffle did not change the ordering")
+	}
+}
+
+func TestShuffleValidators_PreservesWithinBlockOrder(t *testing.T) {
+	// With 1000 validators the block size is minBlockSize (20). Within any
+	// shuffled block the key indices must remain strictly increasing by one.
+	vals := makeValidators("mnemonic-0", 1000)
+	ShuffleValidators(vals, 7)
+
+	blockSize := blockSizeForCount(1000)
+	for start := 0; start < len(vals); start += blockSize {
+		for i := start + 1; i < start+blockSize && i < len(vals); i++ {
+			if vals[i].SourceKeyIndex != vals[i-1].SourceKeyIndex+1 {
+				t.Fatalf("within-block order broken at index %d: %d after %d",
+					i, vals[i].SourceKeyIndex, vals[i-1].SourceKeyIndex)
+			}
+		}
+	}
+}
+
+func TestShuffleValidators_SmallSetNoOp(t *testing.T) {
+	vals := makeValidators("mnemonic-0", minBlockSize)
+	ShuffleValidators(vals, 42)
+
+	for i, v := range vals {
+		if uint64(i) != v.SourceKeyIndex {
+			t.Fatalf("small set should not be shuffled, but index %d moved", i)
+		}
+	}
+}

--- a/validators/validators.go
+++ b/validators/validators.go
@@ -17,4 +17,8 @@ type Validator struct {
 	WithdrawalCredentials []byte
 	Balance               *uint64
 	Status                ValidatorStatus
+
+	// Source identifies where the key originated
+	Source         string
+	SourceKeyIndex uint64
 }


### PR DESCRIPTION
Adds optional block-wise validator shuffling and a validator mapping output to the genesis state generator.

- **Source tracking**: every validator now carries a `Source` + `SourceKeyIndex` (mnemonic `name` / `mnemonic-<i>` / `additional-validators`), so its originating key can be traced after reordering.
- **Block-wise shuffle** (`--shuffle-validators`): splits the validator set into contiguous blocks (size scales `20`→`100` with the set size) and shuffles the block *order* with a deterministic PRNG — seeded from the genesis fork version by default, overridable via `--shuffle-seed`. Intra-block order is preserved to keep the mapping compact. Adds realistic variance to the genesis validator ordering while staying reproducible.
- **Mapping file** (`--validators-mapping-output`): writes a YAML mapping of final state-index ranges → source key ranges, e.g. `- 0-19: { src: "main-mnemonic", from: 0, to: 19 }`. Consecutive same-source, contiguous-key runs are collapsed into a single entry.
- Optional `name` field for mnemonic sources (used as the mapping `src`).
- Unit tests for the shuffle, seed derivation, block sizing, and mapping build/write.
